### PR TITLE
feat: Can pass debug to Pouch option to ... debug Pouch action

### DIFF
--- a/docs/api/cozy-pouch-link.md
+++ b/docs/api/cozy-pouch-link.md
@@ -53,6 +53,9 @@ constructor - Initializes a new PouchLink
 | [opts.replicationInterval] | <code>number</code> |  | Milliseconds between replications |
 | opts.doctypes | <code>Array.&lt;string&gt;</code> |  | Doctypes to replicate |
 | opts.doctypesReplicationOptions | <code>Array.&lt;object&gt;</code> |  | A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote") |
+| opts.pouch | <code>Array.&lt;object&gt;</code> |  |  |
+| opts.pouch.plugins | <code>Array.&lt;object&gt;</code> |  | List of Pouch plugins to use |
+| opts.pouch.options.debug | <code>boolean</code> |  | To debug Pouch action |
 
 <a name="PouchLink+handleOnSync"></a>
 

--- a/packages/cozy-pouch-link/package.json
+++ b/packages/cozy-pouch-link/package.json
@@ -13,8 +13,10 @@
   "dependencies": {
     "cozy-client": "^13.19.0",
     "cozy-device-helper": "^1.7.3",
+    "debug": "^4.1.1",
     "minilog": "^3.1.0",
     "pouchdb-browser": "^7.0.0",
+    "pouchdb-debug": "^7.2.1",
     "pouchdb-find": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/cozy-pouch-link/src/CozyPouchLink.js
+++ b/packages/cozy-pouch-link/src/CozyPouchLink.js
@@ -56,6 +56,9 @@ class PouchLink extends CozyLink {
    * @param {number} [opts.replicationInterval] Milliseconds between replications
    * @param {string[]} opts.doctypes Doctypes to replicate
    * @param {object[]} opts.doctypesReplicationOptions A mapping from doctypes to replication options. All pouch replication options can be used, as well as the "strategy" option that determines which way the replication is done (can be "sync", "fromRemote" or "toRemote")
+   * @param {object[]} opts.pouch
+   * @param {object[]} opts.pouch.plugins List of Pouch plugins to use
+   * @param {boolean} opts.pouch.options.debug To debug Pouch action
    *
    * @returns {object} The PouchLink instance
    */

--- a/packages/cozy-pouch-link/src/PouchManager.js
+++ b/packages/cozy-pouch-link/src/PouchManager.js
@@ -1,12 +1,16 @@
 import PouchDB from 'pouchdb-browser'
+import pouchdbDebug from 'pouchdb-debug'
+
 import fromPairs from 'lodash/fromPairs'
 import forEach from 'lodash/forEach'
 import get from 'lodash/get'
 import map from 'lodash/map'
 import zip from 'lodash/zip'
+
+import { isMobileApp } from 'cozy-device-helper'
+
 import Loop from './loop'
 import { default as helpers } from './helpers'
-import { isMobileApp } from 'cozy-device-helper'
 import logger from './logger'
 
 const { isDesignDocument, isDeletedDocument } = helpers
@@ -114,6 +118,11 @@ class PouchManager {
     const pouchPlugins = get(options, 'pouch.plugins', [])
     const pouchOptions = get(options, 'pouch.options', {})
     forEach(pouchPlugins, plugin => PouchDB.plugin(plugin))
+    if (pouchOptions.debug) {
+      PouchDB.plugin(pouchdbDebug)
+      PouchDB.debug.enable('*')
+    }
+
     this.pouches = fromPairs(
       doctypes.map(doctype => [
         doctype,


### PR DESCRIPTION
Sometimes we need to be able to know what happen in Pouch to see what are the operations that are done and which actions take times. 

<img width="706" alt="Capture d’écran 2020-08-11 à 08 42 01" src="https://user-images.githubusercontent.com/1107936/89865728-8cb9ca00-dbae-11ea-8db8-98dd04b25048.png">
