### PR TITLE
Typing playground

### DIFF
--- a/packages/cozy-client/src/playground.ts
+++ b/packages/cozy-client/src/playground.ts
@@ -1,0 +1,62 @@
+import React from 'react'
+
+import useClient from './hooks/useClient'
+
+type TriggerDoctype = 'io.cozy.triggers'
+type FileDoctype = 'io.cozy.files'
+type Doctype = TriggerDoctype|FileDoctype
+
+type Trigger = {
+  message: object
+};
+type File = {
+  name: string
+};
+type Document = Trigger|File|object;
+
+type QResult<T extends Document> = {
+  data: Array<T>
+}
+interface QDefinition<T> {
+  doctype: T;
+}
+
+type DoctypeOf<T> = T extends { doctype: Doctype} ? T["doctype"] : never;
+type Doctype2Document = {
+  'io.cozy.triggers': Trigger,
+  'io.cozy.files': File,
+  Doctype: Document
+}
+type DocumentType<T extends Doctype> = Doctype2Document[T]
+
+export const Q = <T>(doctype: T): QDefinition<T> => {
+  if (typeof doctype !== 'string') {
+    throw new Error("must provide doctype")
+  }
+
+  const d = doctype
+  return {
+    doctype: d
+  }
+} 
+
+export const useQuery = <T>(qDef: T): QResult<DocumentType<DoctypeOf<T>>> => {
+  const client = useClient()
+  const qs = client.getQueryFromState('1')
+  const Q = typeof qDef
+
+  const data = qs.data
+  return { data }
+}
+
+const FILE_DOCTYPE: FileDoctype = 'io.cozy.files'
+const TRIGGER_DOCTYPE: TriggerDoctype = 'io.cozy.triggers'
+
+const test =() => {
+  const qdef = Q(FILE_DOCTYPE)
+  const result = useQuery(qdef)
+  const first = result.data[0]
+  return first
+}
+
+

--- a/packages/cozy-client/types/playground.d.ts
+++ b/packages/cozy-client/types/playground.d.ts
@@ -1,0 +1,28 @@
+declare type TriggerDoctype = 'io.cozy.triggers';
+declare type FileDoctype = 'io.cozy.files';
+declare type Doctype = TriggerDoctype | FileDoctype;
+declare type Trigger = {
+    message: object;
+};
+declare type File = {
+    name: string;
+};
+declare type Document = Trigger | File | object;
+declare type QResult<T extends Document> = {
+    data: Array<T>;
+};
+interface QDefinition<T> {
+    doctype: T;
+}
+declare type DoctypeOf<T> = T extends {
+    doctype: Doctype;
+} ? T["doctype"] : never;
+declare type Doctype2Document = {
+    'io.cozy.triggers': Trigger;
+    'io.cozy.files': File;
+    Doctype: Document;
+};
+declare type DocumentType<T extends Doctype> = Doctype2Document[T];
+export declare const Q: <T>(doctype: T) => QDefinition<T>;
+export declare const useQuery: <T>(qDef: T) => QResult<DocumentType<DoctypeOf<T>>>;
+export {};


### PR DESCRIPTION
The goal of this playground is to first explore then implement improved types
for cozy-client.

The main goal is to have the data types flow from query definition to query
results seamlessly, when someone issues an io.cozy.triggers request, we should
know that the results will be Trigger documents.

Here, the goal has been achieved inside the playground and we need to port back
the types to their respective components.

- QueryResult<Doctype>
- QueryDefinition<Doctype>
- Export typed doctypes for usage in apps
  - export <TriggerDoctype>"io.cozy.triggers"
  - export <FileDoctype>"io.cozy.files"
- Import doctypes from cozy-doctypes and transform them to types