### PR TITLE
feat(cozy-stack-client): Add SharingCollection read-only methods for groups

### DIFF
--- a/docs/api/cozy-stack-client.md
+++ b/docs/api/cozy-stack-client.md
@@ -2012,6 +2012,8 @@ Implements the `DocumentCollection` API along with specific methods for
     * [.revokeRecipient(sharing, recipientIndex)](#SharingCollection+revokeRecipient)
     * [.setReadOnly(sharing, recipientIndex)](#SharingCollection+setReadOnly)
     * [.setReadWrite(sharing, recipientIndex)](#SharingCollection+setReadWrite)
+    * [.setGroupReadOnly(sharing, groupIndex)](#SharingCollection+setGroupReadOnly)
+    * [.setGroupReadWrite(sharing, groupIndex)](#SharingCollection+setGroupReadWrite)
     * [.revokeGroup(sharing, groupIndex)](#SharingCollection+revokeGroup)
     * [.revokeSelf(sharing)](#SharingCollection+revokeSelf)
     * [.revokeAllRecipients(sharing)](#SharingCollection+revokeAllRecipients)
@@ -2161,6 +2163,30 @@ Upgrade a read-only sharing member to read-write.
 | --- | --- | --- |
 | sharing | [<code>Sharing</code>](#Sharing) | Sharing Object |
 | recipientIndex | <code>number</code> | Index of this recipient in the members array of the sharing |
+
+<a name="SharingCollection+setGroupReadOnly"></a>
+
+### sharingCollection.setGroupReadOnly(sharing, groupIndex)
+Downgrade a sharing member to read-only.
+
+**Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sharing | [<code>Sharing</code>](#Sharing) | Sharing Object |
+| groupIndex | <code>number</code> | Index of this recipient in the members array of the sharing |
+
+<a name="SharingCollection+setGroupReadWrite"></a>
+
+### sharingCollection.setGroupReadWrite(sharing, groupIndex)
+Upgrade a read-only sharing member to read-write.
+
+**Kind**: instance method of [<code>SharingCollection</code>](#SharingCollection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sharing | [<code>Sharing</code>](#Sharing) | Sharing Object |
+| groupIndex | <code>number</code> | Index of this recipient in the members array of the sharing |
 
 <a name="SharingCollection+revokeGroup"></a>
 

--- a/packages/cozy-stack-client/src/SharingCollection.js
+++ b/packages/cozy-stack-client/src/SharingCollection.js
@@ -325,6 +325,32 @@ class SharingCollection extends DocumentCollection {
   }
 
   /**
+   * Downgrade a sharing member to read-only.
+   *
+   * @param {Sharing} sharing Sharing Object
+   * @param {number} groupIndex Index of this recipient in the members array of the sharing
+   */
+  setGroupReadOnly(sharing, groupIndex) {
+    return this.stackClient.fetchJSON(
+      'POST',
+      uri`/sharings/${sharing._id}/groups/${groupIndex}/readonly`
+    )
+  }
+
+  /**
+   * Upgrade a read-only sharing member to read-write.
+   *
+   * @param {Sharing} sharing Sharing Object
+   * @param {number} groupIndex Index of this recipient in the members array of the sharing
+   */
+  setGroupReadWrite(sharing, groupIndex) {
+    return this.stackClient.fetchJSON(
+      'DELETE',
+      uri`/sharings/${sharing._id}/groups/${groupIndex}/readonly`
+    )
+  }
+
+  /**
    * Revoke only one group of the sharing.
    *
    * @param {Sharing} sharing Sharing Object

--- a/packages/cozy-stack-client/src/SharingCollection.spec.js
+++ b/packages/cozy-stack-client/src/SharingCollection.spec.js
@@ -621,6 +621,36 @@ describe('SharingCollection', () => {
     })
   })
 
+  describe('setGroupReadOnly', () => {
+    beforeEach(() => {
+      client.fetch.mockReset()
+      client.fetchJSON.mockResolvedValue({ data: [] })
+    })
+
+    it('should call the right route', async () => {
+      await collection.setGroupReadOnly(SHARING, 1)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        `/sharings/${SHARING._id}/groups/1/readonly`
+      )
+    })
+  })
+
+  describe('setGroupReadWrite', () => {
+    beforeEach(() => {
+      client.fetch.mockReset()
+      client.fetchJSON.mockResolvedValue({ data: [] })
+    })
+
+    it('should call the right route', async () => {
+      await collection.setGroupReadWrite(SHARING, 1)
+      expect(client.fetchJSON).toHaveBeenCalledWith(
+        'DELETE',
+        `/sharings/${SHARING._id}/groups/1/readonly`
+      )
+    })
+  })
+
   describe('addRecipients', () => {
     beforeEach(() => {
       client.fetch.mockReset()


### PR DESCRIPTION
Wrap the POST and DELETE /sharings/:id/groups/:index/readonly endpoints exposed by the stack to toggle a sharing group's read_only flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added group-level sharing controls to set a group as read-only or restore read/write access.
* **Documentation**
  * Updated the public API docs to include the new group permission methods.
* **Tests**
  * Added coverage for the new group permission actions to verify the correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->