### PR TITLE
fix(assistant): Store the model as account data, label the account after the provider

### DIFF
--- a/docs/api/cozy-client/interfaces/models.assistant.Assistant.md
+++ b/docs/api/cozy-client/interfaces/models.assistant.Assistant.md
@@ -87,3 +87,16 @@ ID of the provider
 *Defined in*
 
 [packages/cozy-client/src/models/assistant.js:16](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L16)
+
+***
+
+### providerName
+
+• **providerName**: `string`
+
+Display name of the provider, used to
+name the account. Defaults to the provider id.
+
+*Defined in*
+
+[packages/cozy-client/src/models/assistant.js:17](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L17)

--- a/docs/api/cozy-client/modules/models.assistant.md
+++ b/docs/api/cozy-client/modules/models.assistant.md
@@ -33,7 +33,7 @@ Creates a new assistant with the provided data.
 
 *Defined in*
 
-[packages/cozy-client/src/models/assistant.js:66](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L66)
+[packages/cozy-client/src/models/assistant.js:69](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L69)
 
 ***
 
@@ -60,7 +60,7 @@ Deletes an assistant by its ID.
 
 *Defined in*
 
-[packages/cozy-client/src/models/assistant.js:119](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L119)
+[packages/cozy-client/src/models/assistant.js:122](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L122)
 
 ***
 
@@ -88,4 +88,4 @@ Edit assistant with the provided data.
 
 *Defined in*
 
-[packages/cozy-client/src/models/assistant.js:146](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L146)
+[packages/cozy-client/src/models/assistant.js:149](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L149)

--- a/docs/api/cozy-client/modules/models.assistant.md
+++ b/docs/api/cozy-client/modules/models.assistant.md
@@ -33,7 +33,7 @@ Creates a new assistant with the provided data.
 
 *Defined in*
 
-[packages/cozy-client/src/models/assistant.js:27](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L27)
+[packages/cozy-client/src/models/assistant.js:66](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L66)
 
 ***
 
@@ -60,7 +60,7 @@ Deletes an assistant by its ID.
 
 *Defined in*
 
-[packages/cozy-client/src/models/assistant.js:96](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L96)
+[packages/cozy-client/src/models/assistant.js:119](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L119)
 
 ***
 
@@ -88,4 +88,4 @@ Edit assistant with the provided data.
 
 *Defined in*
 
-[packages/cozy-client/src/models/assistant.js:123](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L123)
+[packages/cozy-client/src/models/assistant.js:146](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/assistant.js#L146)

--- a/packages/cozy-client/src/models/assistant.js
+++ b/packages/cozy-client/src/models/assistant.js
@@ -14,7 +14,46 @@ const ACCOUNT_DOCTYPE = 'io.cozy.accounts'
  * @property {string} baseUrl - Provider's base URL
  * @property {string} [apiKey] - API key for authentication
  * @property {string} providerId - ID of the provider
+ * @property {string} [providerName] - Display name of the provider, used to
+ * name the account. Defaults to the provider id.
  */
+
+/**
+ * Builds the io.cozy.accounts document backing an assistant.
+ *
+ * The account label is derived from `auth[identifier]`, falling back to
+ * `auth.login` — which holds the model. `identifier` points at `accountName`
+ * so the account is labelled after its provider instead.
+ *
+ * @param {Assistant} assistantData - Data for the assistant
+ * @param {object} [provider] - Existing provider account to update
+ * @returns {object} The io.cozy.accounts document to save
+ */
+const buildProviderAccount = (assistantData, provider) => {
+  const { password, ...auth } = provider?.auth || {}
+  const { baseUrl, ...data } = provider?.data || {}
+
+  // No new key means keeping the one the stack holds in `credentials_encrypted`.
+  const apiKey =
+    assistantData.apiKey || (assistantData.baseUrl ? password : undefined)
+
+  return {
+    ...provider,
+    _type: ACCOUNT_DOCTYPE,
+    account_type: assistantData.providerId,
+    identifier: 'accountName',
+    auth: {
+      ...auth,
+      login: assistantData.model,
+      accountName: assistantData.providerName || assistantData.providerId,
+      ...(apiKey ? { password: apiKey } : {})
+    },
+    data: {
+      ...data,
+      ...(assistantData.baseUrl ? { baseUrl: assistantData.baseUrl } : {})
+    }
+  }
+}
 
 /**
  * Creates a new assistant with the provided data.
@@ -27,23 +66,7 @@ const ACCOUNT_DOCTYPE = 'io.cozy.accounts'
 export const createAssistant = async (client, assistantData) => {
   let createdAccountId = null
   try {
-    const account = {
-      _type: ACCOUNT_DOCTYPE,
-      auth: {
-        login: assistantData.model
-      },
-      account_type: assistantData.providerId
-    }
-
-    if (assistantData.baseUrl) {
-      account.data = {
-        baseUrl: assistantData.baseUrl
-      }
-    }
-
-    if (assistantData.apiKey) {
-      account.auth.password = assistantData.apiKey
-    }
+    const account = buildProviderAccount(assistantData)
     const response = await client.save(account)
 
     if (!response.data || !response.data._id) {
@@ -139,30 +162,7 @@ export const editAssistant = async (client, assistantId, assistantData) => {
       throw new Error('Provider account not found for assistant')
     }
 
-    const account = {
-      ...provider,
-      auth: {
-        ...(provider.auth || {}),
-        login: assistantData.model
-      },
-      account_type: assistantData.providerId,
-      data: {
-        ...(provider.data || {})
-      }
-    }
-
-    if (assistantData.baseUrl) {
-      account.data.baseUrl = assistantData.baseUrl
-    } else {
-      delete account.data?.baseUrl
-    }
-
-    // Only update the password if a new API key is explicitly provided
-    if (assistantData.apiKey) {
-      account.auth.password = assistantData.apiKey
-    } else if (!assistantData.baseUrl) {
-      delete account.auth?.password
-    }
+    const account = buildProviderAccount(assistantData, provider)
     const response = await client.save(account)
 
     if (!response.data || !response.data._id) {

--- a/packages/cozy-client/src/models/assistant.js
+++ b/packages/cozy-client/src/models/assistant.js
@@ -21,16 +21,19 @@ const ACCOUNT_DOCTYPE = 'io.cozy.accounts'
 /**
  * Builds the io.cozy.accounts document backing an assistant.
  *
- * The account label is derived from `auth[identifier]`, falling back to
- * `auth.login` — which holds the model. `identifier` points at `accountName`
- * so the account is labelled after its provider instead.
+ * `auth` is the only part the stack encrypts, so it holds the API key alone.
+ * The model and base URL are configuration and live in `data`, where they map
+ * onto the stack's `llm_override`. `identifier` points at `accountName` so the
+ * account is labelled after its provider rather than after `auth.login`.
  *
  * @param {Assistant} assistantData - Data for the assistant
  * @param {object} [provider] - Existing provider account to update
  * @returns {object} The io.cozy.accounts document to save
  */
 const buildProviderAccount = (assistantData, provider) => {
-  const { password, ...auth } = provider?.auth || {}
+  // `login` used to hold the model: dropped so it stops being encrypted with
+  // the API key, and stops outranking `accountName` as the label.
+  const { login, password, ...auth } = provider?.auth || {}
   const { baseUrl, ...data } = provider?.data || {}
 
   // No new key means keeping the one the stack holds in `credentials_encrypted`.
@@ -44,12 +47,12 @@ const buildProviderAccount = (assistantData, provider) => {
     identifier: 'accountName',
     auth: {
       ...auth,
-      login: assistantData.model,
       accountName: assistantData.providerName || assistantData.providerId,
       ...(apiKey ? { password: apiKey } : {})
     },
     data: {
       ...data,
+      model: assistantData.model,
       ...(assistantData.baseUrl ? { baseUrl: assistantData.baseUrl } : {})
     }
   }

--- a/packages/cozy-client/src/models/assistant.spec.js
+++ b/packages/cozy-client/src/models/assistant.spec.js
@@ -1,0 +1,130 @@
+import { createAssistant, editAssistant } from './assistant'
+
+describe('assistant provider account', () => {
+  const assistantData = {
+    name: 'My agent',
+    prompt: 'Be helpful',
+    model: 'gemini-3-pro',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai/v1',
+    providerId: 'google',
+    providerName: 'Google'
+  }
+
+  describe('createAssistant', () => {
+    const buildClient = () => ({
+      save: jest
+        .fn()
+        .mockResolvedValue({ data: { _id: 'account-id', _type: 'whatever' } })
+    })
+
+    it('labels the account after the provider, not after the model', async () => {
+      const client = buildClient()
+
+      await createAssistant(client, assistantData)
+
+      const account = client.save.mock.calls[0][0]
+      expect(account.identifier).toBe('accountName')
+      expect(account.auth.accountName).toBe('Google')
+      expect(account.auth.login).toBe('gemini-3-pro')
+    })
+
+    it('falls back to the provider id when no display name is given', async () => {
+      const client = buildClient()
+
+      await createAssistant(client, {
+        ...assistantData,
+        providerName: undefined
+      })
+
+      const account = client.save.mock.calls[0][0]
+      expect(account.auth.accountName).toBe('google')
+    })
+  })
+
+  describe('editAssistant', () => {
+    const buildClient = provider => ({
+      query: jest.fn().mockResolvedValue({
+        data: { _id: 'assistant-id', relationships: {} },
+        included: [provider]
+      }),
+      save: jest.fn().mockResolvedValue({ data: { _id: 'account-id' } })
+    })
+
+    it('relabels an account named after a previous model', async () => {
+      const client = buildClient({
+        _id: 'account-id',
+        // Label used to be derived from `auth.login`.
+        name: 'gemini-2.5-flash',
+        auth: { login: 'gemini-2.5-flash' }
+      })
+
+      await editAssistant(client, 'assistant-id', assistantData)
+
+      const account = client.save.mock.calls[0][0]
+      expect(account.identifier).toBe('accountName')
+      expect(account.auth.accountName).toBe('Google')
+    })
+
+    // Pre-existing coupling, pinned because the builder now expresses it once.
+    it('replaces the stored API key when a new one is given', async () => {
+      const client = buildClient({
+        _id: 'account-id',
+        auth: { accountName: 'Google', password: 'sk-old' }
+      })
+
+      await editAssistant(client, 'assistant-id', {
+        ...assistantData,
+        apiKey: 'sk-new'
+      })
+
+      expect(client.save.mock.calls[0][0].auth.password).toBe('sk-new')
+    })
+
+    it('keeps the stored API key when only a baseUrl is given', async () => {
+      const client = buildClient({
+        _id: 'account-id',
+        auth: { accountName: 'Google', password: 'sk-old' }
+      })
+
+      await editAssistant(client, 'assistant-id', {
+        ...assistantData,
+        apiKey: undefined
+      })
+
+      expect(client.save.mock.calls[0][0].auth.password).toBe('sk-old')
+    })
+
+    it('drops the stored API key when neither key nor baseUrl is given', async () => {
+      const client = buildClient({
+        _id: 'account-id',
+        auth: { accountName: 'Google', password: 'sk-old' }
+      })
+
+      await editAssistant(client, 'assistant-id', {
+        ...assistantData,
+        apiKey: undefined,
+        baseUrl: undefined
+      })
+
+      const account = client.save.mock.calls[0][0]
+      expect(account.auth.password).toBeUndefined()
+      expect(account.data.baseUrl).toBeUndefined()
+    })
+
+    it('preserves the fields it does not own', async () => {
+      const client = buildClient({
+        _id: 'account-id',
+        _rev: '3-abc',
+        cozyMetadata: { createdAt: 'yesterday' },
+        auth: { accountName: 'Google', credentials_encrypted: 'blob' }
+      })
+
+      await editAssistant(client, 'assistant-id', assistantData)
+
+      const account = client.save.mock.calls[0][0]
+      expect(account._rev).toBe('3-abc')
+      expect(account.cozyMetadata).toEqual({ createdAt: 'yesterday' })
+      expect(account.auth.credentials_encrypted).toBe('blob')
+    })
+  })
+})

--- a/packages/cozy-client/src/models/assistant.spec.js
+++ b/packages/cozy-client/src/models/assistant.spec.js
@@ -17,7 +17,31 @@ describe('assistant provider account', () => {
         .mockResolvedValue({ data: { _id: 'account-id', _type: 'whatever' } })
     })
 
-    it('labels the account after the provider, not after the model', async () => {
+    it('stores the model as configuration, not as a credential', async () => {
+      const client = buildClient()
+
+      await createAssistant(client, assistantData)
+
+      const account = client.save.mock.calls[0][0]
+      expect(account.data.model).toBe('gemini-3-pro')
+      // A model in `auth` would be duplicated into `credentials_encrypted`.
+      expect(account.auth.login).toBeUndefined()
+    })
+
+    it('keeps the model next to the other llm_override fields', async () => {
+      const client = buildClient()
+
+      await createAssistant(client, { ...assistantData, apiKey: 'sk-1234' })
+
+      const account = client.save.mock.calls[0][0]
+      expect(account.data).toEqual({
+        model: 'gemini-3-pro',
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai/v1'
+      })
+      expect(account.auth.password).toBe('sk-1234')
+    })
+
+    it('labels the account after the provider', async () => {
       const client = buildClient()
 
       await createAssistant(client, assistantData)
@@ -25,7 +49,8 @@ describe('assistant provider account', () => {
       const account = client.save.mock.calls[0][0]
       expect(account.identifier).toBe('accountName')
       expect(account.auth.accountName).toBe('Google')
-      expect(account.auth.login).toBe('gemini-3-pro')
+      // `name` is computed by the stack from `auth[identifier]` on creation
+      expect(account.name).toBeUndefined()
     })
 
     it('falls back to the provider id when no display name is given', async () => {
@@ -50,11 +75,27 @@ describe('assistant provider account', () => {
       save: jest.fn().mockResolvedValue({ data: { _id: 'account-id' } })
     })
 
-    it('relabels an account named after a previous model', async () => {
+    it('migrates an account that still holds the model in auth.login', async () => {
       const client = buildClient({
         _id: 'account-id',
-        // Label used to be derived from `auth.login`.
-        name: 'gemini-2.5-flash',
+        auth: {
+          login: 'gemini-2.5-flash',
+          credentials_encrypted: 'encrypted-blob'
+        }
+      })
+
+      await editAssistant(client, 'assistant-id', assistantData)
+
+      const account = client.save.mock.calls[0][0]
+      expect(account.data.model).toBe('gemini-3-pro')
+      expect(account.auth.login).toBeUndefined()
+      // Left alone: the stack reads the API key from it, never the model.
+      expect(account.auth.credentials_encrypted).toBe('encrypted-blob')
+    })
+
+    it('relabels an account created before the naming fix', async () => {
+      const client = buildClient({
+        _id: 'account-id',
         auth: { login: 'gemini-2.5-flash' }
       })
 
@@ -115,6 +156,7 @@ describe('assistant provider account', () => {
       const client = buildClient({
         _id: 'account-id',
         _rev: '3-abc',
+        name: 'Google',
         cozyMetadata: { createdAt: 'yesterday' },
         auth: { accountName: 'Google', credentials_encrypted: 'blob' }
       })
@@ -125,6 +167,21 @@ describe('assistant provider account', () => {
       expect(account._rev).toBe('3-abc')
       expect(account.cozyMetadata).toEqual({ createdAt: 'yesterday' })
       expect(account.auth.credentials_encrypted).toBe('blob')
+    })
+
+    it('updates the model of an already migrated account', async () => {
+      const client = buildClient({
+        _id: 'account-id',
+        identifier: 'accountName',
+        auth: { accountName: 'Google' },
+        data: { model: 'gemini-2.5-flash', baseUrl: 'https://example.org' }
+      })
+
+      await editAssistant(client, 'assistant-id', assistantData)
+
+      const account = client.save.mock.calls[0][0]
+      expect(account.data.model).toBe('gemini-3-pro')
+      expect(account.data.baseUrl).toBe(assistantData.baseUrl)
     })
   })
 })

--- a/packages/cozy-client/types/models/assistant.d.ts
+++ b/packages/cozy-client/types/models/assistant.d.ts
@@ -30,5 +30,10 @@ export type Assistant = {
      * - ID of the provider
      */
     providerId: string;
+    /**
+     * - Display name of the provider, used to
+     * name the account. Defaults to the provider id.
+     */
+    providerName?: string;
 };
 import CozyClient from "../CozyClient";


### PR DESCRIPTION
## Problem

Two symptoms, one cause.

1. **Editing an assistant's model had no effect** unless the API key was retyped at the same time — the conversation kept running on the model the assistant was created with.
2. **The provider account was labelled after the model** (`gemini-2.5-flash`) instead of after the provider (`Google`), and that label drifted every time the model changed.

Both come from the model being stored in `auth.login`.

`auth` is the part of an `io.cozy.accounts` document the stack encrypts: `encryptMap` bundles `auth.login` and `auth.password` into `auth.credentials_encrypted`. That blob is only rebuilt when a password is present in the incoming document, so editing only the model left an encrypted copy pointing at the *previous* model — and that copy was the one the stack forwarded to OpenRAG.

The same field also drives the account's display label, which is derived from `auth[account.identifier]` and falls back to `auth.login` (cozy-harvest-lib `getLabel`, cozy-doctypes `Account.getAccountName`, stack-side `ComputeName`). Hence the model showing up as the account name.

## Fix

**`11db857c` — label the account after the provider.** Set `auth.accountName` to the provider name and point `identifier` at it, the documented way to label an account with no identifiable login. Falls back to `providerId` when no display name is given.

**`82b39f32` — move the model out of `auth`.** It is configuration, not a credential, so it goes to `data.model`, next to the `data.baseUrl` that was already there — out of reach of the encryptor.

| | before | after |
|---|---|---|
| model | `auth.login`, duplicated into the encrypted blob | `data.model` |
| API key | `auth.password` → encrypted blob | unchanged |
| base URL | `data.baseUrl` | unchanged |

`auth` now holds what must be encrypted, `data` holds the rest, and the triplet maps one-to-one onto the stack's `llm_override` = `{model, api_key, base_url}`.

The two commits are in this order on purpose: the second removes `auth.login`, which is what the label used to fall back to. Without the first, the label would fall through to `account._id`.

## Migration

`editAssistant` drops a leftover `auth.login`, so accounts created before the move migrate as soon as they are edited. The encrypted blob is deliberately left alone — the stack reads the API key from it and never the model, so there is nothing stale left to resurrect.

## ⚠️ Deploy order

**[linagora/cozy-stack#4886](https://github.com/linagora/cozy-stack/pull/4886) must be deployed before this ships.**

That PR makes the stack read `data.model`, with a fallback to `auth.login`, so it tolerates accounts in either shape. This client no longer writes `auth.login` at all: against an older stack, `buildLLMOverride` would find neither field and send an override with no model. OpenRAG would answer with its default model, with no error surfaced.

Once this is deployed and existing accounts have been rewritten, the `auth.login` fallback can be dropped from the stack.

## Tests

7 cases in `assistant.spec.js` covering both functions: the model landing in `data.model`, `auth.login` never being written, the provider label and its `providerId` fallback, the migration of a legacy account (including that its encrypted blob is preserved), and an already-migrated account being updated in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant provider accounts can display a friendly provider name, with the provider ID used as a fallback.
  * Model settings are stored consistently with other assistant configuration.
  * Creating and editing assistant accounts preserves existing credentials and account data.
* **Bug Fixes**
  * Legacy accounts are automatically migrated to the updated model storage and naming format.
  * Existing encrypted credentials remain intact during account updates.
* **Documentation**
  * Updated Assistant API documentation to describe provider names and configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->