### PR TITLE
feat(models): add the io.cozy.banners model

### DIFF
--- a/docs/api/cozy-client/interfaces/models.banner.Banner.md
+++ b/docs/api/cozy-client/interfaces/models.banner.Banner.md
@@ -1,0 +1,199 @@
+[cozy-client](../README.md) / [models](../modules/models.md) / [banner](../modules/models.banner.md) / Banner
+
+# Interface: Banner<>
+
+[models](../modules/models.md).[banner](../modules/models.banner.md).Banner
+
+An io.cozy.banners document
+
+## Properties
+
+### \_id
+
+• **\_id**: `string`
+
+Identifier of the document, minted by CouchDB
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:76](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L76)
+
+***
+
+### \_rev
+
+• **\_rev**: `string`
+
+Revision identifier of the document
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:77](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L77)
+
+***
+
+### bannerId
+
+• **bannerId**: `string`
+
+Identifier of the banner itself
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:78](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L78)
+
+***
+
+### category
+
+• **category**: [`BannerCategory`](../modules/models.banner.md#bannercategory)
+
+What the banner is about
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:79](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L79)
+
+***
+
+### cozyMetadata
+
+• **cozyMetadata**: `any`
+
+Document lifecycle metadata
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:91](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L91)
+
+***
+
+### cta
+
+• **cta**: [`BannerCta`](models.banner.BannerCta.md)
+
+Optional call to action
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:84](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L84)
+
+***
+
+### dismissedAt
+
+• **dismissedAt**: `string`
+
+When the user dismissed this banner
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:86](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L86)
+
+***
+
+### dismissible
+
+• **dismissible**: `boolean`
+
+Whether the client offers a dismiss control
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:85](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L85)
+
+***
+
+### endsAt
+
+• **endsAt**: `string`
+
+End of the validity window, exclusive
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:89](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L89)
+
+***
+
+### lang
+
+• **lang**: `string`
+
+BCP 47 tag of the language text is written in
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:83](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L83)
+
+***
+
+### priority
+
+• **priority**: `number`
+
+Sort order, highest first
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:87](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L87)
+
+***
+
+### severity
+
+• **severity**: [`BannerSeverity`](../modules/models.banner.md#bannerseverity)
+
+info, warning or error
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:80](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L80)
+
+***
+
+### source
+
+• **source**: `any`
+
+What produced the document
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:90](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L90)
+
+***
+
+### startsAt
+
+• **startsAt**: `string`
+
+Start of the validity window, inclusive
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:88](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L88)
+
+***
+
+### surface
+
+• **surface**: [`BannerSurface`](../modules/models.banner.md#bannersurface)
+
+banner or modal
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:81](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L81)
+
+***
+
+### text
+
+• **text**: `string`
+
+The message, in the language given by lang
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:82](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L82)

--- a/docs/api/cozy-client/interfaces/models.banner.BannerCta.md
+++ b/docs/api/cozy-client/interfaces/models.banner.BannerCta.md
@@ -1,0 +1,29 @@
+[cozy-client](../README.md) / [models](../modules/models.md) / [banner](../modules/models.banner.md) / BannerCta
+
+# Interface: BannerCta<>
+
+[models](../modules/models.md).[banner](../modules/models.banner.md).BannerCta
+
+## Properties
+
+### label
+
+• **label**: `string`
+
+The label, plain text, in the same language as the banner text
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:43](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L43)
+
+***
+
+### url
+
+• **url**: `string`
+
+Absolute https URL the label points to
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:44](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L44)

--- a/docs/api/cozy-client/interfaces/models.banner.DismissOptions.md
+++ b/docs/api/cozy-client/interfaces/models.banner.DismissOptions.md
@@ -1,0 +1,17 @@
+[cozy-client](../README.md) / [models](../modules/models.md) / [banner](../modules/models.banner.md) / DismissOptions
+
+# Interface: DismissOptions<>
+
+[models](../modules/models.md).[banner](../modules/models.banner.md).DismissOptions
+
+## Properties
+
+### dismissedAt
+
+• **dismissedAt**: `string`
+
+The timestamp to record, defaults to now
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:71](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L71)

--- a/docs/api/cozy-client/interfaces/models.banner.VisibleBannersOptions.md
+++ b/docs/api/cozy-client/interfaces/models.banner.VisibleBannersOptions.md
@@ -1,0 +1,29 @@
+[cozy-client](../README.md) / [models](../modules/models.md) / [banner](../modules/models.banner.md) / VisibleBannersOptions
+
+# Interface: VisibleBannersOptions<>
+
+[models](../modules/models.md).[banner](../modules/models.banner.md).VisibleBannersOptions
+
+## Properties
+
+### now
+
+• **now**: `Date`
+
+The current time, defaults to now
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:61](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L61)
+
+***
+
+### supportedDoctypeVersion
+
+• **supportedDoctypeVersion**: `number`
+
+The highest version this client handles
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:62](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L62)

--- a/docs/api/cozy-client/modules/models.banner.md
+++ b/docs/api/cozy-client/modules/models.banner.md
@@ -1,0 +1,489 @@
+[cozy-client](../README.md) / [models](models.md) / banner
+
+# Namespace: banner
+
+[models](models.md).banner
+
+## Interfaces
+
+*   [Banner](../interfaces/models.banner.Banner.md)
+*   [BannerCta](../interfaces/models.banner.BannerCta.md)
+*   [DismissOptions](../interfaces/models.banner.DismissOptions.md)
+*   [VisibleBannersOptions](../interfaces/models.banner.VisibleBannersOptions.md)
+
+## Type aliases
+
+### BannerCategory
+
+Ƭ **BannerCategory**<>: `"quota"` | `"billing"` | `"trial"` | `"account"` | `"system"`
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:48](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L48)
+
+***
+
+### BannerClient
+
+Ƭ **BannerClient**<>: `default`
+
+A CozyClient instance
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:66](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L66)
+
+***
+
+### BannerSeverity
+
+Ƭ **BannerSeverity**<>: `"info"` | `"warning"` | `"error"`
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:52](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L52)
+
+***
+
+### BannerSurface
+
+Ƭ **BannerSurface**<>: `"banner"` | `"modal"`
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:56](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L56)
+
+## Variables
+
+### BANNERS_DOCTYPE
+
+• `Const` **BANNERS_DOCTYPE**: `"io.cozy.banners"`
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:7](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L7)
+
+***
+
+### BANNERS_QUERY_NAME
+
+• `Const` **BANNERS_QUERY_NAME**: `string`
+
+The name the banners query is stored under. It is namespaced rather than the
+bare doctype: `client.query` keys the store entry on this name but keys the
+in-flight promise on the definition, so an unrelated consumer naming its own
+`io.cozy.banners` query would make this one resolve nothing while that query
+is loading.
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:101](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L101)
+
+***
+
+### KNOWN_SEVERITIES
+
+• `Const` **KNOWN_SEVERITIES**: readonly [`BannerSeverity`](models.banner.md#bannerseverity)\[]
+
+The severities the doctype defines. A value outside this list is rendered
+with DEFAULT_SEVERITY. Frozen because the fallbacks read it at call time, so
+a consumer mutating it would change what every other consumer renders.
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:22](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L22)
+
+***
+
+### KNOWN_SURFACES
+
+• `Const` **KNOWN_SURFACES**: readonly [`BannerSurface`](models.banner.md#bannersurface)\[]
+
+The surfaces the doctype defines. A value outside this list is rendered on
+DEFAULT_SURFACE. Frozen for the same reason as KNOWN_SEVERITIES.
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:31](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L31)
+
+***
+
+### SUPPORTED_DOCTYPE_VERSION
+
+• `Const` **SUPPORTED_DOCTYPE_VERSION**: `1`
+
+The version of the io.cozy.banners shape this code was written against.
+A document declaring a higher cozyMetadata.doctypeVersion is skipped.
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:13](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L13)
+
+## Functions
+
+### buildBannersQuery
+
+▸ **buildBannersQuery**(): `Query`
+
+Query for the banners of the current instance.
+
+The query is named so every consumer shares one store entry rather than
+minting a new one per call, and the limit is lifted because the whole
+collection is read in full.
+
+*Returns*
+
+`Query`
+
+A named query
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:112](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L112)
+
+***
+
+### byPriority
+
+▸ **byPriority**(`a`, `b`): `number`
+
+Highest priority first, then bannerId ascending so every client orders
+identically when priorities are equal.
+
+The tie break compares code units rather than calling localeCompare, whose
+result depends on the runtime's locale and ICU build. A missing or non
+numeric priority sorts as 0 instead of producing NaN, which would make the
+comparator intransitive and the sort order engine defined.
+
+Documents that lost their bannerId fall back on \_id, as the deduplication
+does, so two of them do not compare equal and land in whatever order the
+database returned them in.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `a` | [`Banner`](../interfaces/models.banner.Banner.md) | A banner |
+| `b` | [`Banner`](../interfaces/models.banner.Banner.md) | Another banner |
+
+*Returns*
+
+`number`
+
+The comparison result
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:255](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L255)
+
+***
+
+### dismiss
+
+▸ **dismiss**(`client`, `banner`, `options?`): `Promise`<{ `data`: [`Banner`](../interfaces/models.banner.Banner.md)  }>
+
+Records a dismissal. The field is idempotent, so a conflict is resolved by
+reading the document again and writing the value on the fresh revision.
+
+The dismissal is written to the document it is given. During a doctypeVersion
+migration the stack materializes the same bannerId under several versions,
+and the sibling documents are not reached from here.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/CozyClient.md) | A CozyClient instance |
+| `banner` | [`Banner`](../interfaces/models.banner.Banner.md) & { `_id`: `string`  } | The banner to dismiss, as stored |
+| `options` | [`DismissOptions`](../interfaces/models.banner.DismissOptions.md) | - |
+
+*Returns*
+
+`Promise`<{ `data`: [`Banner`](../interfaces/models.banner.Banner.md)  }>
+
+> } The dismissed document, null when it is gone
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:567](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L567)
+
+***
+
+### getActiveBanner
+
+▸ **getActiveBanner**(`client`, `options?`): `Promise`<[`Banner`](../interfaces/models.banner.Banner.md)>
+
+The single banner to display, for a surface that shows one at a time.
+
+**`throws`** {Error} When the doctype cannot be read, a missing permission included
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/CozyClient.md) | A CozyClient instance |
+| `options` | [`VisibleBannersOptions`](../interfaces/models.banner.VisibleBannersOptions.md) | - |
+
+*Returns*
+
+`Promise`<[`Banner`](../interfaces/models.banner.Banner.md)>
+
+The highest priority banner, or null
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:549](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L549)
+
+***
+
+### getActiveBanners
+
+▸ **getActiveBanners**(`client`, `options?`): `Promise`<[`Banner`](../interfaces/models.banner.Banner.md)\[]>
+
+The banners to display, in the order to display them. This is the entry
+point: it queries the doctype and applies every rule the contract defines,
+so a caller does not compose the helpers itself.
+
+The whole collection is read rather than filtered by a Mango selector. The
+validity window, the dismissal and the version filter would each need their
+own index, and the doctype keeps the collection small on purpose: the stack
+deletes a banner when its condition clears.
+
+**`throws`** {Error} When the doctype cannot be read, a missing permission included
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`CozyClient`](../classes/CozyClient.md) | A CozyClient instance |
+| `options` | [`VisibleBannersOptions`](../interfaces/models.banner.VisibleBannersOptions.md) | - |
+
+*Returns*
+
+`Promise`<[`Banner`](../interfaces/models.banner.Banner.md)\[]>
+
+The banners to display, ready to render
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:534](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L534)
+
+***
+
+### getCta
+
+▸ **getCta**(`banner`): [`BannerCta`](../interfaces/models.banner.BannerCta.md)
+
+A call to action is only rendered when it carries a label and points at
+https, so a locally authored document cannot turn into a platform styled
+link on any scheme, and no banner renders a button the user cannot read.
+The scheme is matched case insensitively since URL schemes are.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `banner` | [`Banner`](../interfaces/models.banner.Banner.md) | The document to read |
+
+*Returns*
+
+[`BannerCta`](../interfaces/models.banner.BannerCta.md)
+
+The call to action, or null when there is none to show
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:299](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L299)
+
+***
+
+### getSeverity
+
+▸ **getSeverity**(`banner`): [`BannerSeverity`](models.banner.md#bannerseverity)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `banner` | [`Banner`](../interfaces/models.banner.Banner.md) | The document to read |
+
+*Returns*
+
+[`BannerSeverity`](models.banner.md#bannerseverity)
+
+The severity to render, falling back when unknown
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:270](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L270)
+
+***
+
+### getSurface
+
+▸ **getSurface**(`banner`): [`BannerSurface`](models.banner.md#bannersurface)
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `banner` | [`Banner`](../interfaces/models.banner.Banner.md) | The document to read |
+
+*Returns*
+
+[`BannerSurface`](models.banner.md#bannersurface)
+
+The surface to render on, falling back when unknown
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:279](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L279)
+
+***
+
+### getVisibleBanners
+
+▸ **getVisibleBanners**(`banners`, `options?`): [`Banner`](../interfaces/models.banner.Banner.md)\[]
+
+The banners a client displays, in the order it displays them.
+
+A dismissal applies to the bannerId rather than to the single document
+carrying it, so a banner dismissed against one version stays hidden once the
+client moves to another. Deduplication runs last, on the documents that are
+actually renderable, so a newer version sitting outside its validity window
+never suppresses the older one that is still live.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `banners` | [`Banner`](../interfaces/models.banner.Banner.md)\[] | The documents read from the doctype |
+| `options` | [`VisibleBannersOptions`](../interfaces/models.banner.VisibleBannersOptions.md) | - |
+
+*Returns*
+
+[`Banner`](../interfaces/models.banner.Banner.md)\[]
+
+The visible banners, ordered
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:398](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L398)
+
+***
+
+### isDismissed
+
+▸ **isDismissed**(`banner`): `boolean`
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `banner` | [`Banner`](../interfaces/models.banner.Banner.md) | The document to check |
+
+*Returns*
+
+`boolean`
+
+True when the user dismissed it
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:205](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L205)
+
+***
+
+### isInWindow
+
+▸ **isInWindow**(`banner`, `now?`): `boolean`
+
+The window is inclusive on startsAt and exclusive on endsAt, and an absent
+endsAt is open ended. A malformed bound hides the banner: a document whose
+window cannot be read is not one a client can decide to show.
+
+An absent startsAt hides it too. The doctype makes cta, dismissedAt and
+endsAt the only fields that may be missing, so a document with no lower bound
+is not open ended, it is unreadable. Treating it as "no bound" would make the
+missing field more permissive than a malformed one, and would let anything
+able to rewrite the document turn a scheduled banner into a permanent one by
+deleting both bounds.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `banner` | [`Banner`](../interfaces/models.banner.Banner.md) | The document to check |
+| `now` | `Date` | - |
+
+*Returns*
+
+`boolean`
+
+True when the banner applies at that time
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:223](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L223)
+
+***
+
+### isSupported
+
+▸ **isSupported**(`banner`, `supportedVersion?`): `boolean`
+
+*Parameters*
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `banner` | [`Banner`](../interfaces/models.banner.Banner.md) | `undefined` | The document to check |
+| `supportedVersion` | `number` | `SUPPORTED_DOCTYPE_VERSION` | - |
+
+*Returns*
+
+`boolean`
+
+True when the shape is one this client can read
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:173](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L173)
+
+***
+
+### isTrusted
+
+▸ **isTrusted**(`banner`): `boolean`
+
+Documents are only trusted when the stack wrote them. Permissions scope by
+doctype and verb, never by field, so any application allowed to record a
+dismissal is also able to author a document that looks like a platform
+message.
+
+This is not a security boundary, and should not be read as one. The stack
+does not own this field: cozy-client keeps whatever `cozyMetadata` the caller
+passes (CozyClient.js, ensureCozyMetadata spreads it last), so an application
+can set `createdByApp: 'stack'` on a document it authored itself and pass
+this check. It catches an application writing under its own name, which is
+the ordinary mistake, not one deliberately impersonating the stack. Enforcing
+that needs the doctype to be stack write only on the server side.
+
+It also only speaks to who created the document. An application holding write
+permission can rewrite the fields of a stack authored one, which the platform
+cannot prevent, so a client escapes text and never interprets markup in it.
+
+*Parameters*
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `banner` | [`Banner`](../interfaces/models.banner.Banner.md) | The document to check |
+
+*Returns*
+
+`boolean`
+
+True when the stack is the author
+
+*Defined in*
+
+[packages/cozy-client/src/models/banner.js:138](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/banner.js#L138)

--- a/docs/api/cozy-client/modules/models.md
+++ b/docs/api/cozy-client/modules/models.md
@@ -8,6 +8,7 @@
 *   [ai](models.ai.md)
 *   [applications](models.applications.md)
 *   [assistant](models.assistant.md)
+*   [banner](models.banner.md)
 *   [contact](models.contact.md)
 *   [dacc](models.dacc.md)
 *   [doctypes](models.doctypes.md)
@@ -34,7 +35,7 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/index.js:25](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L25)
+[packages/cozy-client/src/models/index.js:26](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L26)
 
 ***
 
@@ -44,4 +45,4 @@
 
 *Defined in*
 
-[packages/cozy-client/src/models/index.js:24](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L24)
+[packages/cozy-client/src/models/index.js:25](https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/models/index.js#L25)

--- a/packages/cozy-client/src/models/__fixtures__/io.cozy.banners.json
+++ b/packages/cozy-client/src/models/__fixtures__/io.cozy.banners.json
@@ -1,0 +1,1152 @@
+{
+  "$comment": "Shared contract vectors for io.cozy.banners. Every client implementing the doctype runs these and must produce `expected` from `input`. Published with the doctype in cozy-doctypes, alongside docs/io.cozy.banners.md.",
+  "now": "2026-07-22T12:00:00Z",
+  "supportedDoctypeVersion": 1,
+  "expectedShape": "An ordered list of the banners a client displays, each reduced to the values that rendering depends on: bannerId, the severity and surface actually used after any fallback, and whether a call to action is shown.",
+  "cases": [
+    {
+      "name": "no documents renders nothing",
+      "input": [],
+      "expected": []
+    },
+    {
+      "name": "higher priority renders first",
+      "input": [
+        {
+          "_id": "doc001",
+          "_rev": "1-aaa",
+          "bannerId": "b.low",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 10,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        },
+        {
+          "_id": "doc002",
+          "_rev": "1-aaa",
+          "bannerId": "a.high",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 100,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "a.high",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        },
+        {
+          "bannerId": "b.low",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "equal priority breaks on bannerId, compared by code unit rather than locale",
+      "input": [
+        {
+          "_id": "doc003",
+          "_rev": "1-aaa",
+          "bannerId": "a.lower",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        },
+        {
+          "_id": "doc004",
+          "_rev": "1-aaa",
+          "bannerId": "B.upper",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "B.upper",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        },
+        {
+          "bannerId": "a.lower",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "a window that has not started is hidden",
+      "input": [
+        {
+          "_id": "doc005",
+          "_rev": "1-aaa",
+          "bannerId": "future",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-23T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": []
+    },
+    {
+      "name": "startsAt is inclusive",
+      "input": [
+        {
+          "_id": "doc006",
+          "_rev": "1-aaa",
+          "bannerId": "starting",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-22T12:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "starting",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "endsAt is exclusive",
+      "input": [
+        {
+          "_id": "doc007",
+          "_rev": "1-aaa",
+          "bannerId": "ending",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": "2026-07-22T12:00:00Z",
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": []
+    },
+    {
+      "name": "a window still open is visible",
+      "input": [
+        {
+          "_id": "doc008",
+          "_rev": "1-aaa",
+          "bannerId": "open",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": "2026-07-23T00:00:00Z",
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "open",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "a null endsAt is open ended",
+      "input": [
+        {
+          "_id": "doc009",
+          "_rev": "1-aaa",
+          "bannerId": "openended",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "openended",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "an absent endsAt means the same as null",
+      "input": [
+        {
+          "_id": "doc010",
+          "_rev": "1-aaa",
+          "bannerId": "absentend",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "absentend",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "an unparseable startsAt hides the banner",
+      "input": [
+        {
+          "_id": "doc011",
+          "_rev": "1-aaa",
+          "bannerId": "badstart",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "not a date",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": []
+    },
+    {
+      "name": "an unparseable endsAt hides the banner",
+      "input": [
+        {
+          "_id": "doc012",
+          "_rev": "1-aaa",
+          "bannerId": "badend",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": "22/07/2026",
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": []
+    },
+    {
+      "name": "a dismissed banner is hidden",
+      "input": [
+        {
+          "_id": "doc013",
+          "_rev": "1-aaa",
+          "bannerId": "dismissed",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": "2026-07-21T08:00:00Z",
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": []
+    },
+    {
+      "name": "a dismissal recorded while dismissible wins over dismissible false",
+      "input": [
+        {
+          "_id": "doc014",
+          "_rev": "1-aaa",
+          "bannerId": "locked",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": false,
+          "dismissedAt": "2026-07-21T08:00:00Z",
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": []
+    },
+    {
+      "name": "an unknown category still renders",
+      "input": [
+        {
+          "_id": "doc015",
+          "_rev": "1-aaa",
+          "bannerId": "unknowncat",
+          "category": "weather",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "unknowncat",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "an unknown severity renders as warning",
+      "input": [
+        {
+          "_id": "doc016",
+          "_rev": "1-aaa",
+          "bannerId": "unknownsev",
+          "category": "quota",
+          "severity": "critical",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "unknownsev",
+          "severity": "warning",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "an unknown surface renders as banner",
+      "input": [
+        {
+          "_id": "doc017",
+          "_rev": "1-aaa",
+          "bannerId": "unknownsurface",
+          "category": "quota",
+          "severity": "info",
+          "surface": "toast",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "unknownsurface",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "an https call to action renders",
+      "input": [
+        {
+          "_id": "doc018",
+          "_rev": "1-aaa",
+          "bannerId": "withcta",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "cta": {
+            "label": "Upgrade",
+            "url": "https://example.org/plans"
+          },
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "withcta",
+          "severity": "info",
+          "surface": "banner",
+          "cta": true
+        }
+      ]
+    },
+    {
+      "name": "a call to action on any other scheme is dropped and the banner still renders",
+      "input": [
+        {
+          "_id": "doc019",
+          "_rev": "1-aaa",
+          "bannerId": "badcta",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "cta": {
+            "label": "Upgrade",
+            "url": "javascript:alert(1)"
+          },
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "badcta",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "a null call to action renders no button",
+      "input": [
+        {
+          "_id": "doc020",
+          "_rev": "1-aaa",
+          "bannerId": "nullcta",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "cta": null,
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "nullcta",
+          "severity": "info",
+          "surface": "banner",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "a document written by anything other than the stack is not rendered",
+      "input": [
+        {
+          "_id": "doc021",
+          "_rev": "1-aaa",
+          "bannerId": "untrusted",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "drive",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": []
+    },
+    {
+      "name": "a document above the supported version is skipped",
+      "supportedDoctypeVersion": 1,
+      "input": [
+        {
+          "_id": "doc022",
+          "_rev": "1-aaa",
+          "bannerId": "toonew",
+          "category": "quota",
+          "severity": "error",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "2",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": []
+    },
+    {
+      "name": "the highest supported version of a bannerId wins, and the others are not rendered",
+      "supportedDoctypeVersion": 2,
+      "input": [
+        {
+          "_id": "doc023",
+          "_rev": "1-aaa",
+          "bannerId": "dual",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        },
+        {
+          "_id": "doc024",
+          "_rev": "1-aaa",
+          "bannerId": "dual",
+          "category": "quota",
+          "severity": "error",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "3",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        },
+        {
+          "_id": "doc025",
+          "_rev": "1-aaa",
+          "bannerId": "dual",
+          "category": "quota",
+          "severity": "info",
+          "surface": "modal",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "2",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "dual",
+          "severity": "info",
+          "surface": "modal",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "at equal versions the most recently updated document wins",
+      "supportedDoctypeVersion": 1,
+      "input": [
+        {
+          "_id": "doc026",
+          "_rev": "1-aaa",
+          "bannerId": "same",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-02T00:00:00Z"
+          }
+        },
+        {
+          "_id": "doc027",
+          "_rev": "1-aaa",
+          "bannerId": "same",
+          "category": "quota",
+          "severity": "info",
+          "surface": "modal",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-09T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "same",
+          "severity": "info",
+          "surface": "modal",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "at equal versions and equal updatedAt the lowest _id wins",
+      "supportedDoctypeVersion": 1,
+      "input": [
+        {
+          "_id": "bbb",
+          "_rev": "1-aaa",
+          "bannerId": "tied",
+          "category": "quota",
+          "severity": "error",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        },
+        {
+          "_id": "aaa",
+          "_rev": "1-aaa",
+          "bannerId": "tied",
+          "category": "quota",
+          "severity": "info",
+          "surface": "modal",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "bannerId": "tied",
+          "severity": "info",
+          "surface": "modal",
+          "cta": false
+        }
+      ]
+    },
+    {
+      "name": "a dismissal of one version hides every version of that bannerId",
+      "supportedDoctypeVersion": 2,
+      "input": [
+        {
+          "_id": "doc030",
+          "_rev": "1-aaa",
+          "bannerId": "shared",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": "2026-07-21T08:00:00Z",
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        },
+        {
+          "_id": "doc031",
+          "_rev": "1-aaa",
+          "bannerId": "shared",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "2",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": []
+    },
+    {
+      "name": "a dismissal recorded on a version this client cannot read still hides the banner",
+      "supportedDoctypeVersion": 1,
+      "input": [
+        {
+          "_id": "docx01",
+          "_rev": "1-aaa",
+          "bannerId": "crossversion",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": null,
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "1",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        },
+        {
+          "_id": "docx02",
+          "_rev": "1-aaa",
+          "bannerId": "crossversion",
+          "category": "quota",
+          "severity": "info",
+          "surface": "banner",
+          "text": "Message.",
+          "lang": "en",
+          "dismissible": true,
+          "dismissedAt": "2026-07-21T08:00:00Z",
+          "priority": 50,
+          "startsAt": "2026-07-01T00:00:00Z",
+          "endsAt": null,
+          "source": {
+            "trigger": "test",
+            "at": "2026-07-01T00:00:00Z"
+          },
+          "cozyMetadata": {
+            "createdAt": "2026-07-01T00:00:00Z",
+            "createdByApp": "stack",
+            "doctypeVersion": "2",
+            "metadataVersion": 1,
+            "updatedAt": "2026-07-01T00:00:00Z"
+          }
+        }
+      ],
+      "expected": []
+    }
+  ]
+}

--- a/packages/cozy-client/src/models/banner.js
+++ b/packages/cozy-client/src/models/banner.js
@@ -1,0 +1,635 @@
+import isValid from 'date-fns/isValid'
+import parseISO from 'date-fns/parseISO'
+
+import { Q } from '../queries/dsl'
+import { getCreatedByApp } from './utils'
+
+export const BANNERS_DOCTYPE = 'io.cozy.banners'
+
+/**
+ * The version of the io.cozy.banners shape this code was written against.
+ * A document declaring a higher cozyMetadata.doctypeVersion is skipped.
+ */
+export const SUPPORTED_DOCTYPE_VERSION = 1
+
+/**
+ * The severities the doctype defines. A value outside this list is rendered
+ * with DEFAULT_SEVERITY. Frozen because the fallbacks read it at call time, so
+ * a consumer mutating it would change what every other consumer renders.
+ *
+ * @type {readonly BannerSeverity[]}
+ */
+export const KNOWN_SEVERITIES = ['info', 'warning', 'error']
+Object.freeze(KNOWN_SEVERITIES)
+
+/**
+ * The surfaces the doctype defines. A value outside this list is rendered on
+ * DEFAULT_SURFACE. Frozen for the same reason as KNOWN_SEVERITIES.
+ *
+ * @type {readonly BannerSurface[]}
+ */
+export const KNOWN_SURFACES = ['banner', 'modal']
+Object.freeze(KNOWN_SURFACES)
+
+/** @type {BannerSeverity} */
+const DEFAULT_SEVERITY = 'warning'
+/** @type {BannerSurface} */
+const DEFAULT_SURFACE = 'banner'
+
+const STACK_APP = 'stack'
+
+/**
+ * @typedef {object} BannerCta
+ * @property {string} label - The label, plain text, in the same language as the banner text
+ * @property {string} url - Absolute https URL the label points to
+ */
+
+/**
+ * @typedef {'quota'|'billing'|'trial'|'account'|'system'} BannerCategory
+ */
+
+/**
+ * @typedef {'info'|'warning'|'error'} BannerSeverity
+ */
+
+/**
+ * @typedef {'banner'|'modal'} BannerSurface
+ */
+
+/**
+ * @typedef {object} VisibleBannersOptions
+ * @property {Date} [now] - The current time, defaults to now
+ * @property {number} [supportedDoctypeVersion] - The highest version this client handles
+ */
+
+/**
+ * @typedef {import("../CozyClient").default} BannerClient A CozyClient instance
+ */
+
+/**
+ * @typedef {object} DismissOptions
+ * @property {string} [dismissedAt] - The timestamp to record, defaults to now
+ */
+
+/**
+ * @typedef {object} Banner An io.cozy.banners document
+ * @property {string} [_id] - Identifier of the document, minted by CouchDB
+ * @property {string} [_rev] - Revision identifier of the document
+ * @property {string} bannerId - Identifier of the banner itself
+ * @property {BannerCategory} category - What the banner is about
+ * @property {BannerSeverity} severity - info, warning or error
+ * @property {BannerSurface} surface - banner or modal
+ * @property {string} text - The message, in the language given by lang
+ * @property {string} lang - BCP 47 tag of the language text is written in
+ * @property {BannerCta|null} [cta] - Optional call to action
+ * @property {boolean} dismissible - Whether the client offers a dismiss control
+ * @property {string|null} [dismissedAt] - When the user dismissed this banner
+ * @property {number} priority - Sort order, highest first
+ * @property {string} startsAt - Start of the validity window, inclusive
+ * @property {string|null} [endsAt] - End of the validity window, exclusive
+ * @property {object} [source] - What produced the document
+ * @property {object} [cozyMetadata] - Document lifecycle metadata
+ */
+
+/**
+ * The name the banners query is stored under. It is namespaced rather than the
+ * bare doctype: `client.query` keys the store entry on this name but keys the
+ * in-flight promise on the definition, so an unrelated consumer naming its own
+ * `io.cozy.banners` query would make this one resolve nothing while that query
+ * is loading.
+ */
+export const BANNERS_QUERY_NAME = `${BANNERS_DOCTYPE}/all`
+
+/**
+ * Query for the banners of the current instance.
+ *
+ * The query is named so every consumer shares one store entry rather than
+ * minting a new one per call, and the limit is lifted because the whole
+ * collection is read in full.
+ *
+ * @returns {import('../types').Query} A named query
+ */
+export const buildBannersQuery = () => ({
+  definition: Q(BANNERS_DOCTYPE).UNSAFE_noLimit(),
+  options: { as: BANNERS_QUERY_NAME }
+})
+
+/**
+ * Documents are only trusted when the stack wrote them. Permissions scope by
+ * doctype and verb, never by field, so any application allowed to record a
+ * dismissal is also able to author a document that looks like a platform
+ * message.
+ *
+ * This is not a security boundary, and should not be read as one. The stack
+ * does not own this field: cozy-client keeps whatever `cozyMetadata` the caller
+ * passes (CozyClient.js, ensureCozyMetadata spreads it last), so an application
+ * can set `createdByApp: 'stack'` on a document it authored itself and pass
+ * this check. It catches an application writing under its own name, which is
+ * the ordinary mistake, not one deliberately impersonating the stack. Enforcing
+ * that needs the doctype to be stack write only on the server side.
+ *
+ * It also only speaks to who created the document. An application holding write
+ * permission can rewrite the fields of a stack authored one, which the platform
+ * cannot prevent, so a client escapes text and never interprets markup in it.
+ *
+ * @param {Banner} banner - The document to check
+ * @returns {boolean} True when the stack is the author
+ */
+export const isTrusted = banner => getCreatedByApp(banner) === STACK_APP
+
+/**
+ * cozy-stack writes numbers as strings in places, `cozyMetadata` declares
+ * `doctypeVersion` that way platform wide, so a value is parsed rather than
+ * compared as it comes. `Number()` alone is not enough: it maps null, "", false
+ * and [] to a finite 0, which would read as a real version or a real priority
+ * rather than as an unusable value, so only a number or a non blank string is
+ * parsed at all.
+ *
+ * @param {any} value - The value to read
+ * @param {number} fallback - What an absent or unusable value means
+ * @returns {number} The parsed number, or the fallback
+ */
+const toNumber = (value, fallback) => {
+  const parsed =
+    typeof value === 'number' ||
+    (typeof value === 'string' && value.trim() !== '')
+      ? Number(value)
+      : NaN
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+/**
+ * @param {Banner} banner - The document to read
+ * @returns {number} The version, defaulting to 1 for a missing or unusable one
+ */
+const doctypeVersion = banner =>
+  toNumber(banner?.cozyMetadata?.doctypeVersion, 1)
+
+/**
+ * @param {Banner} banner - The document to check
+ * @param {number} [supportedVersion] - The highest version this client handles
+ * @returns {boolean} True when the shape is one this client can read
+ */
+export const isSupported = (
+  banner,
+  supportedVersion = SUPPORTED_DOCTYPE_VERSION
+) => doctypeVersion(banner) <= supportedVersion
+
+/**
+ * A null value and an absent key mean the same thing for dismissedAt and
+ * endsAt, and `new Date(null)` is the Unix epoch rather than "no date", so
+ * every date is null checked before being parsed.
+ *
+ * Returns a timestamp rather than a Date so the comparisons stay primitive,
+ * and NaN when the value is present but unparseable, which the callers reject
+ * rather than silently treating as "no bound".
+ *
+ * This is the only date parser in the file. `Date.parse` is deliberately not
+ * used anywhere: it accepts implementation defined formats that `parseISO`
+ * rejects, and the two disagree by the local UTC offset on a date only value,
+ * so mixing them would give one document two different instants.
+ *
+ * @param {string|null|undefined} value - An ISO 8601 timestamp
+ * @returns {number|null} The timestamp, NaN when malformed, null when absent
+ */
+const toTime = value => {
+  if (value === null || value === undefined) return null
+  const parsed = parseISO(value)
+  return isValid(parsed) ? parsed.getTime() : NaN
+}
+
+/**
+ * @param {Banner} banner - The document to check
+ * @returns {boolean} True when the user dismissed it
+ */
+export const isDismissed = banner => banner?.dismissedAt != null
+
+/**
+ * The window is inclusive on startsAt and exclusive on endsAt, and an absent
+ * endsAt is open ended. A malformed bound hides the banner: a document whose
+ * window cannot be read is not one a client can decide to show.
+ *
+ * An absent startsAt hides it too. The doctype makes cta, dismissedAt and
+ * endsAt the only fields that may be missing, so a document with no lower bound
+ * is not open ended, it is unreadable. Treating it as "no bound" would make the
+ * missing field more permissive than a malformed one, and would let anything
+ * able to rewrite the document turn a scheduled banner into a permanent one by
+ * deleting both bounds.
+ *
+ * @param {Banner} banner - The document to check
+ * @param {Date} [now] - The current time
+ * @returns {boolean} True when the banner applies at that time
+ */
+export const isInWindow = (banner, now = new Date()) => {
+  const startsAt = toTime(banner?.startsAt)
+  const endsAt = toTime(banner?.endsAt)
+  if (startsAt === null || Number.isNaN(startsAt)) return false
+  if (Number.isNaN(endsAt)) return false
+
+  const at = now.getTime()
+  if (Number.isNaN(at)) return false
+  if (at < startsAt) return false
+  if (endsAt !== null && at >= endsAt) return false
+  return true
+}
+
+const priorityOf = banner => toNumber(banner?.priority, 0)
+
+/**
+ * Highest priority first, then bannerId ascending so every client orders
+ * identically when priorities are equal.
+ *
+ * The tie break compares code units rather than calling localeCompare, whose
+ * result depends on the runtime's locale and ICU build. A missing or non
+ * numeric priority sorts as 0 instead of producing NaN, which would make the
+ * comparator intransitive and the sort order engine defined.
+ *
+ * Documents that lost their bannerId fall back on _id, as the deduplication
+ * does, so two of them do not compare equal and land in whatever order the
+ * database returned them in.
+ *
+ * @param {Banner} a - A banner
+ * @param {Banner} b - Another banner
+ * @returns {number} The comparison result
+ */
+export const byPriority = (a, b) => {
+  const byRank = priorityOf(b) - priorityOf(a)
+  if (byRank !== 0) return byRank
+
+  const idA = String(a?.bannerId ?? a?._id ?? '')
+  const idB = String(b?.bannerId ?? b?._id ?? '')
+  if (idA < idB) return -1
+  if (idA > idB) return 1
+  return 0
+}
+
+/**
+ * @param {Banner} banner - The document to read
+ * @returns {BannerSeverity} The severity to render, falling back when unknown
+ */
+export const getSeverity = banner =>
+  KNOWN_SEVERITIES.includes(banner?.severity)
+    ? banner.severity
+    : DEFAULT_SEVERITY
+
+/**
+ * @param {Banner} banner - The document to read
+ * @returns {BannerSurface} The surface to render on, falling back when unknown
+ */
+export const getSurface = banner =>
+  KNOWN_SURFACES.includes(banner?.surface) ? banner.surface : DEFAULT_SURFACE
+
+/**
+ * Whitespace plus the zero width characters `trim` leaves behind. A label made
+ * only of these renders as a button with nothing on it. They are stripped to
+ * decide whether the label is empty, never from the label itself, so a script
+ * that uses a zero width joiner between glyphs keeps it.
+ */
+const BLANK = /[\s\u200B-\u200D\uFEFF]/g
+
+/**
+ * A call to action is only rendered when it carries a label and points at
+ * https, so a locally authored document cannot turn into a platform styled
+ * link on any scheme, and no banner renders a button the user cannot read.
+ * The scheme is matched case insensitively since URL schemes are.
+ *
+ * @param {Banner} banner - The document to read
+ * @returns {BannerCta|null} The call to action, or null when there is none to show
+ */
+export const getCta = banner => {
+  const cta = banner?.cta
+  if (!cta || typeof cta.url !== 'string') return null
+  if (typeof cta.label !== 'string' || cta.label.replace(BLANK, '') === '') {
+    return null
+  }
+  return isHttpsUrl(cta.url) ? cta : null
+}
+
+/**
+ * A prefix check accepts "https://" and "https:example.org", which do not point
+ * where they look like they point, so the value is parsed instead. The parser
+ * rejects an https URL with no host outright, so reaching the scheme comparison
+ * already means there is one.
+ *
+ * @param {string} raw - The candidate URL
+ * @returns {boolean} True when it is an absolute https URL
+ */
+const isHttpsUrl = raw => {
+  try {
+    return new URL(raw).protocol === 'https:'
+  } catch (error) {
+    return false
+  }
+}
+
+const updatedAtOf = banner => {
+  const at = toTime(banner?.cozyMetadata?.updatedAt)
+  return Number.isFinite(at) ? at : 0
+}
+
+/**
+ * Orders two documents carrying the same bannerId, most relevant first. The
+ * highest supported doctypeVersion wins; equal versions fall back on the most
+ * recently written document and then on _id, so the winner never depends on
+ * the order the rows came back in.
+ *
+ * @param {Banner} candidate - The document being considered
+ * @param {Banner} current - The document currently held
+ * @returns {boolean} True when candidate should replace current
+ */
+const supersedes = (candidate, current) => {
+  const byVersion = doctypeVersion(candidate) - doctypeVersion(current)
+  if (byVersion !== 0) return byVersion > 0
+
+  const byUpdate = updatedAtOf(candidate) - updatedAtOf(current)
+  if (byUpdate !== 0) return byUpdate > 0
+
+  return String(candidate?._id ?? '') < String(current?._id ?? '')
+}
+
+/**
+ * The identity two documents are grouped and dismissed under. bannerId and _id
+ * are kept in separate namespaces: sharing one would let a document whose _id
+ * happens to equal another document's bannerId dismiss or supersede it. A
+ * document carrying neither keys on itself, so unrelated ones do not collapse
+ * onto a single `undefined` key.
+ *
+ * @param {Banner} banner - The document to key
+ * @returns {string|Banner} The grouping key
+ */
+const groupKey = banner => {
+  if (banner?.bannerId != null) return `bannerId:${banner.bannerId}`
+  if (banner?._id != null) return `_id:${banner._id}`
+  return banner
+}
+
+/**
+ * Keeps the highest supported version of each bannerId. Without this the
+ * documents materialized on both sides of a version bump render twice.
+ *
+ * @param {Banner[]} banners - The documents to reduce
+ * @returns {Banner[]} One document per bannerId
+ */
+const keepHighestVersion = banners => {
+  const best = new Map()
+  for (const banner of banners) {
+    const key = groupKey(banner)
+    const current = best.get(key)
+    if (current === undefined || supersedes(banner, current)) {
+      best.set(key, banner)
+    }
+  }
+  return Array.from(best.values())
+}
+
+/**
+ * The banners a client displays, in the order it displays them.
+ *
+ * A dismissal applies to the bannerId rather than to the single document
+ * carrying it, so a banner dismissed against one version stays hidden once the
+ * client moves to another. Deduplication runs last, on the documents that are
+ * actually renderable, so a newer version sitting outside its validity window
+ * never suppresses the older one that is still live.
+ *
+ * @param {Banner[]} banners - The documents read from the doctype
+ * @param {VisibleBannersOptions} [options] - Options
+ * @returns {Banner[]} The visible banners, ordered
+ */
+export const getVisibleBanners = (banners, options = {}) => {
+  const now =
+    options.now instanceof Date && !Number.isNaN(options.now.getTime())
+      ? options.now
+      : new Date()
+  // Validated rather than defaulted with ??, which only guards null and
+  // undefined: a NaN reaching isSupported makes every comparison false and
+  // hides every banner with no error.
+  const supportedVersion = toNumber(
+    options.supportedDoctypeVersion,
+    SUPPORTED_DOCTYPE_VERSION
+  )
+
+  // Only documents the stack wrote are read at all, dismissals included: a
+  // dismissal on a document an application authored must not hide a platform
+  // message.
+  const trusted = (banners ?? []).filter(isTrusted)
+
+  // Collected before the version filter: a dismissal recorded by a client on a
+  // newer version of the document still applies to a client that only reads the
+  // older one, which would otherwise render a banner the user has closed.
+  const dismissed = new Set(trusted.filter(isDismissed).map(groupKey))
+
+  return keepHighestVersion(
+    trusted.filter(
+      banner =>
+        isSupported(banner, supportedVersion) &&
+        !dismissed.has(groupKey(banner)) &&
+        isInWindow(banner, now)
+    )
+  )
+    .sort(byPriority)
+    .map(resolve)
+}
+
+/**
+ * Applies every fallback the doctype defines, so a caller renders what it is
+ * given instead of reaching for the helpers itself: an unknown severity or
+ * surface is already replaced, and a call to action that is not an absolute
+ * https URL is already dropped.
+ *
+ * The doctype guarantees that a non dismissible banner on the modal surface
+ * carries a call to action, so the user is never left without a way out.
+ * Dropping an unusable one would break that guarantee and paint a blocking
+ * dialog with no dismiss control and no button, so the banner falls back to the
+ * surface that is never blocking.
+ *
+ * The document is returned unchanged when no fallback applied. The store relies
+ * on referential equality, and copying every banner on every read would make a
+ * memoized renderer repaint on every poll tick. An absent cta is not left
+ * absent though: the resolved shape always carries the key, so a caller reads
+ * one value rather than checking for both null and undefined.
+ *
+ * @param {Banner} banner - A visible banner
+ * @returns {Banner} The same banner, ready to render
+ */
+const resolve = banner => {
+  const severity = getSeverity(banner)
+  const cta = getCta(banner)
+  const surface =
+    getSurface(banner) === 'modal' && cta === null && !banner?.dismissible
+      ? DEFAULT_SURFACE
+      : getSurface(banner)
+
+  if (
+    severity === banner?.severity &&
+    surface === banner?.surface &&
+    cta === banner?.cta
+  ) {
+    return banner
+  }
+  return { ...banner, severity, surface, cta }
+}
+
+/**
+ * A conflict reaches this code in two shapes: a FetchError from the stack,
+ * which carries the HTTP status, and a PouchDB conflict, which the pouch link
+ * rewraps into a plain Error that only keeps the message.
+ *
+ * @param {Error & {status?: number}} error - The error to classify
+ * @returns {boolean} True when the write lost a revision race
+ */
+const isConflict = error =>
+  error?.status === 409 || /Document update conflict/.test(error?.message ?? '')
+
+/**
+ * `client.query` does not always resolve a response. It resolves undefined when
+ * the client was built with an `onError` callback, which swallows the rejection,
+ * and when a query named the same as this one is already in flight with a
+ * different definition. Both are indistinguishable from an empty collection
+ * once the response is read, so they are rejected here instead: reporting a
+ * failed read as "there is nothing" hides a banner the user should see, and
+ * reports a dismissal that never happened as done.
+ *
+ * @param {object} response - The response of a query
+ * @returns {object} The same response
+ * @throws {Error} When the query resolved nothing
+ */
+const requireResponse = response => {
+  if (response === null || response === undefined) {
+    throw new Error(
+      `The ${BANNERS_DOCTYPE} query resolved nothing. Either the client swallowed the error through its onError option, or another query is registered under the name ${BANNERS_QUERY_NAME}.`
+    )
+  }
+  return response
+}
+
+/**
+ * The links disagree on how a missing document comes back: the stack link
+ * resolves `{data: null}` while the pouch link resolves `{data: []}`, and an
+ * empty array is truthy. Both mean there is nothing to write to.
+ *
+ * @param {object} response - The response of a getById query
+ * @returns {Banner|null} The document, or null when there is none
+ */
+const readOne = response => {
+  const data = requireResponse(response)?.data
+  const doc = Array.isArray(data) ? data[0] : data
+  return doc?._id ? doc : null
+}
+
+/**
+ * The banners to display, in the order to display them. This is the entry
+ * point: it queries the doctype and applies every rule the contract defines,
+ * so a caller does not compose the helpers itself.
+ *
+ * The whole collection is read rather than filtered by a Mango selector. The
+ * validity window, the dismissal and the version filter would each need their
+ * own index, and the doctype keeps the collection small on purpose: the stack
+ * deletes a banner when its condition clears.
+ *
+ * @param {BannerClient} client - A CozyClient instance
+ * @param {VisibleBannersOptions} [options] - Options
+ * @returns {Promise<Banner[]>} The banners to display, ready to render
+ * @throws {Error} When the doctype cannot be read, a missing permission included
+ */
+export const getActiveBanners = async (client, options = {}) => {
+  const { definition, options: queryOptions } = buildBannersQuery()
+  const data = requireResponse(await client.query(definition, queryOptions))
+    ?.data
+  return getVisibleBanners(Array.isArray(data) ? data : [], options)
+}
+
+/**
+ * The single banner to display, for a surface that shows one at a time.
+ *
+ * @param {BannerClient} client - A CozyClient instance
+ * @param {VisibleBannersOptions} [options] - Options
+ * @returns {Promise<Banner|null>} The highest priority banner, or null
+ * @throws {Error} When the doctype cannot be read, a missing permission included
+ */
+export const getActiveBanner = async (client, options = {}) => {
+  const [first] = await getActiveBanners(client, options)
+  return first ?? null
+}
+
+/**
+ * Records a dismissal. The field is idempotent, so a conflict is resolved by
+ * reading the document again and writing the value on the fresh revision.
+ *
+ * The dismissal is written to the document it is given. During a doctypeVersion
+ * migration the stack materializes the same bannerId under several versions,
+ * and the sibling documents are not reached from here.
+ *
+ * @param {BannerClient} client - A CozyClient instance
+ * @param {Banner & {_id: string}} banner - The banner to dismiss, as stored
+ * @param {DismissOptions} [options] - Options
+ * @returns {Promise<{data: Banner|null}>} The dismissed document, null when it is gone
+ */
+export const dismiss = async (client, banner, options = {}) => {
+  const dismissedAt = options.dismissedAt ?? new Date().toISOString()
+  const id = banner?._id
+  if (!id) throw new Error('A banner needs an _id to be dismissed')
+
+  // The doctype requires the dismissal on every version of a bannerId, not
+  // only the document the caller happens to hold. Writing one leaves a client
+  // that reads an older version still showing a banner the user closed, and
+  // the read side only compensates while both siblings are alive.
+  const siblings = await findSiblings(client, banner)
+
+  let result = { data: null }
+  for (const sibling of siblings) {
+    const written = await writeDismissal(client, sibling._id, dismissedAt)
+    // The caller is answered with the document it asked about.
+    if (sibling._id === id) result = written
+  }
+  return result
+}
+
+/**
+ * Every stored document sharing the banner's identity, the one the caller holds
+ * included. The whole collection is read because the versions of a bannerId are
+ * not reachable by id, and the doctype keeps the collection small on purpose.
+ *
+ * @param {BannerClient} client - A CozyClient instance
+ * @param {Banner} banner - The banner being dismissed
+ * @returns {Promise<Banner[]>} The documents to write the dismissal to
+ */
+const findSiblings = async (client, banner) => {
+  const { definition, options: queryOptions } = buildBannersQuery()
+  const response = requireResponse(await client.query(definition, queryOptions))
+  const data = Array.isArray(response.data) ? response.data : []
+  const key = groupKey(banner)
+  const siblings = data.filter(doc => doc?._id && groupKey(doc) === key)
+  // The document may have been deleted between the read and the click, in which
+  // case there is nothing left to write to.
+  return siblings.length > 0 ? siblings : []
+}
+
+/** How many times the write is attempted before a conflict reaches the caller. */
+const DISMISS_ATTEMPTS = 2
+
+const writeDismissal = async (client, id, dismissedAt) => {
+  for (let attempt = 1; attempt <= DISMISS_ATTEMPTS; attempt++) {
+    const stored = readOne(await client.query(Q(BANNERS_DOCTYPE).getById(id)))
+    // The stack deletes a banner when its condition clears, so there can be
+    // nothing left to dismiss by the time the user clicks.
+    if (!stored) return { data: null }
+    // Another client got there first, and the field is idempotent.
+    if (isDismissed(stored)) return { data: stored }
+
+    try {
+      // _type is written after the document, not before it: a document that
+      // carries its own _type would otherwise override the doctype and route
+      // the write somewhere else entirely.
+      return await client.save({
+        ...stored,
+        _type: BANNERS_DOCTYPE,
+        dismissedAt
+      })
+    } catch (error) {
+      // The write lost a revision race, so the document is read again and the
+      // value written on the fresh revision. A second conflict reaches the
+      // caller rather than looping.
+      if (!isConflict(error) || attempt === DISMISS_ATTEMPTS) throw error
+    }
+  }
+}

--- a/packages/cozy-client/src/models/banner.spec.js
+++ b/packages/cozy-client/src/models/banner.spec.js
@@ -1,0 +1,761 @@
+import {
+  BANNERS_DOCTYPE,
+  BANNERS_QUERY_NAME,
+  getActiveBanner,
+  getActiveBanners,
+  byPriority,
+  dismiss,
+  getCta,
+  getSeverity,
+  getSurface,
+  getVisibleBanners,
+  isDismissed,
+  isInWindow,
+  isSupported,
+  isTrusted
+} from './banner'
+import vectors from './__fixtures__/io.cozy.banners.json'
+import MockDate from 'mockdate'
+
+/**
+ * The fixtures are the shared contract vectors published with the doctype in
+ * cozy-doctypes (fixtures/io.cozy.banners.json). Every client implementing
+ * io.cozy.banners runs the same cases, so the implementations are checked
+ * against one specification rather than against each other.
+ */
+describe('io.cozy.banners contract vectors', () => {
+  const now = new Date(vectors.now)
+
+  it.each(vectors.cases.map(testCase => [testCase.name, testCase]))(
+    '%s',
+    (name, testCase) => {
+      const visible = getVisibleBanners(testCase.input, {
+        now,
+        supportedDoctypeVersion:
+          testCase.supportedDoctypeVersion ?? vectors.supportedDoctypeVersion
+      })
+
+      // No helper calls: getVisibleBanners returns banners ready to render,
+      // with every fallback already applied.
+      const rendered = visible.map(banner => ({
+        bannerId: banner.bannerId,
+        severity: banner.severity,
+        surface: banner.surface,
+        cta: banner.cta !== null
+      }))
+
+      expect(rendered).toEqual(testCase.expected)
+    }
+  )
+})
+
+describe('isTrusted', () => {
+  it('should reject a document written by an application', () => {
+    expect(isTrusted({ cozyMetadata: { createdByApp: 'drive' } })).toBe(false)
+  })
+
+  it('should reject a document with no metadata', () => {
+    expect(isTrusted({})).toBe(false)
+    expect(isTrusted(undefined)).toBe(false)
+  })
+})
+
+const stackBanner = attributes => ({
+  bannerId: 'quota.exceeded',
+  category: 'quota',
+  severity: 'info',
+  surface: 'banner',
+  text: 'Message.',
+  lang: 'en',
+  dismissible: true,
+  dismissedAt: null,
+  priority: 50,
+  startsAt: '2026-07-01T00:00:00Z',
+  endsAt: null,
+  cozyMetadata: {
+    createdByApp: 'stack',
+    doctypeVersion: 1,
+    metadataVersion: 1
+  },
+  ...attributes
+})
+
+const now = new Date('2026-07-22T12:00:00Z')
+const idsOf = banners => banners.map(banner => banner.bannerId)
+
+describe('getSurface', () => {
+  it('should keep every surface the doctype defines', () => {
+    expect(getSurface({ surface: 'banner' })).toBe('banner')
+    expect(getSurface({ surface: 'modal' })).toBe('modal')
+  })
+
+  it('should fall back for a surface the doctype no longer defines', () => {
+    expect(getSurface({ surface: 'inline' })).toBe('banner')
+  })
+})
+
+describe('getSeverity', () => {
+  it('should keep every severity the doctype defines', () => {
+    expect(getSeverity({ severity: 'info' })).toBe('info')
+    expect(getSeverity({ severity: 'warning' })).toBe('warning')
+    expect(getSeverity({ severity: 'error' })).toBe('error')
+  })
+})
+
+describe('getCta', () => {
+  it('should drop a call to action with no readable label', () => {
+    expect(getCta({ cta: { url: 'https://example.org' } })).toBe(null)
+    expect(getCta({ cta: { label: '', url: 'https://example.org' } })).toBe(
+      null
+    )
+    // Whitespace and a zero width space render as a button with nothing on it.
+    expect(getCta({ cta: { label: '  ', url: 'https://example.org' } })).toBe(
+      null
+    )
+    expect(
+      getCta({ cta: { label: '\u200B', url: 'https://example.org' } })
+    ).toBe(null)
+  })
+
+  it('should accept a scheme written in any case', () => {
+    const cta = { label: 'Upgrade', url: 'HTTPS://example.org' }
+    expect(getCta({ cta })).toBe(cta)
+  })
+})
+
+describe('isInWindow', () => {
+  it('should hide a banner whose window cannot be read', () => {
+    expect(isInWindow(stackBanner({ endsAt: 'not-a-date' }), now)).toBe(false)
+    expect(isInWindow(stackBanner({ startsAt: '2026-13-45' }), now)).toBe(false)
+  })
+
+  it('should hide a banner with no start bound rather than treat it as open', () => {
+    // startsAt is not one of the fields the doctype allows to be missing, so an
+    // absent one is an unreadable window. Treating it as "no lower bound" would
+    // make deleting the field enough to turn a scheduled banner into a
+    // permanent one, which anything able to rewrite the document could do.
+    expect(isInWindow(stackBanner({ startsAt: undefined }), now)).toBe(false)
+    expect(isInWindow(stackBanner({ startsAt: null }), now)).toBe(false)
+    expect(
+      idsOf(
+        getVisibleBanners(
+          [stackBanner({ startsAt: undefined, endsAt: null })],
+          {
+            now
+          }
+        )
+      )
+    ).toEqual([])
+  })
+
+  it('should default to the current time', () => {
+    MockDate.set('2026-07-22T12:00:00Z')
+    try {
+      expect(
+        isInWindow(stackBanner({ startsAt: '2026-08-01T00:00:00Z' }))
+      ).toBe(false)
+      expect(isInWindow(stackBanner())).toBe(true)
+    } finally {
+      MockDate.reset()
+    }
+  })
+})
+
+describe('isDismissed', () => {
+  it('should read an absent value as not dismissed', () => {
+    expect(isDismissed({ dismissedAt: null })).toBe(false)
+    expect(isDismissed({})).toBe(false)
+    expect(isDismissed(undefined)).toBe(false)
+  })
+})
+
+describe('isSupported', () => {
+  it('should default to the version this client was written against', () => {
+    expect(isSupported(stackBanner())).toBe(true)
+  })
+})
+
+describe('byPriority', () => {
+  it('should order equal priorities by code unit rather than by locale', () => {
+    const banners = [{ bannerId: 'a.x' }, { bannerId: 'B.x' }]
+    expect(idsOf([...banners].sort(byPriority))).toEqual(['B.x', 'a.x'])
+  })
+
+  it('should stay transitive when a priority is missing', () => {
+    const high = { bannerId: 'z.high', priority: 100 }
+    const none = { bannerId: 'm.none' }
+    const low = { bannerId: 'a.low', priority: 10 }
+
+    expect(byPriority(high, none)).toBeLessThan(0)
+    expect(byPriority(none, low)).toBeGreaterThan(0)
+    expect(byPriority(high, low)).toBeLessThan(0)
+  })
+})
+
+describe('getVisibleBanners', () => {
+  it('should not let an out of window version hide a live one', () => {
+    const live = stackBanner({ _id: 'v1' })
+    const future = stackBanner({
+      _id: 'v2',
+      startsAt: '2026-08-01T00:00:00Z',
+      cozyMetadata: { createdByApp: 'stack', doctypeVersion: 2 }
+    })
+
+    const visible = getVisibleBanners([live, future], {
+      now,
+      supportedDoctypeVersion: 2
+    })
+
+    expect(idsOf(visible)).toEqual(['quota.exceeded'])
+  })
+
+  it('should keep a bannerId hidden once any of its versions is dismissed', () => {
+    const dismissed = stackBanner({
+      _id: 'v1',
+      dismissedAt: '2026-07-20T00:00:00Z'
+    })
+    const upgraded = stackBanner({
+      _id: 'v2',
+      cozyMetadata: { createdByApp: 'stack', doctypeVersion: 2 }
+    })
+
+    const visible = getVisibleBanners([dismissed, upgraded], {
+      now,
+      supportedDoctypeVersion: 2
+    })
+
+    expect(visible).toEqual([])
+  })
+
+  it('should not depend on the order the documents came back in', () => {
+    const older = stackBanner({
+      _id: 'a',
+      priority: 10,
+      cozyMetadata: {
+        createdByApp: 'stack',
+        doctypeVersion: 1,
+        updatedAt: '2026-07-01T00:00:00Z'
+      }
+    })
+    const newer = stackBanner({
+      _id: 'b',
+      priority: 90,
+      cozyMetadata: {
+        createdByApp: 'stack',
+        doctypeVersion: 1,
+        updatedAt: '2026-07-10T00:00:00Z'
+      }
+    })
+
+    const one = getVisibleBanners([older, newer], { now })
+    const other = getVisibleBanners([newer, older], { now })
+
+    expect(one).toEqual(other)
+    expect(one[0]._id).toBe('b')
+  })
+
+  it('should keep documents that lost their bannerId apart', () => {
+    const first = stackBanner({ _id: 'a', bannerId: undefined })
+    const second = stackBanner({ _id: 'b', bannerId: undefined })
+
+    expect(getVisibleBanners([first, second], { now })).toHaveLength(2)
+  })
+
+  it('should ignore a dismissal recorded by anything but the stack', () => {
+    // An application holding write permission on the doctype could otherwise
+    // suppress a platform message by authoring a dismissed document of its own,
+    // without touching the one the stack wrote.
+    const live = stackBanner({ _id: 'stack' })
+    const forged = stackBanner({
+      _id: 'forged',
+      dismissedAt: '2026-07-20T00:00:00Z',
+      cozyMetadata: { createdByApp: 'drive', doctypeVersion: 1 }
+    })
+
+    expect(idsOf(getVisibleBanners([forged, live], { now }))).toEqual([
+      'quota.exceeded'
+    ])
+  })
+
+  it('should not leave a blocking modal without a way out', () => {
+    // The doctype guarantees a non dismissible modal carries a call to action.
+    // Dropping an unusable one must not paint a dialog with no dismiss control
+    // and no button.
+    const trapped = stackBanner({
+      surface: 'modal',
+      dismissible: false,
+      cta: { label: 'Upgrade', url: 'http://example.org/plans' }
+    })
+
+    const [visible] = getVisibleBanners([trapped], { now })
+
+    expect(visible.cta).toBeNull()
+    expect(visible.surface).toBe('banner')
+  })
+
+  it('should keep a modal whose call to action survived', () => {
+    const usable = stackBanner({
+      surface: 'modal',
+      dismissible: false,
+      cta: { label: 'Upgrade', url: 'https://example.org/plans' }
+    })
+
+    expect(getVisibleBanners([usable], { now })[0].surface).toBe('modal')
+  })
+
+  it('should not let a version written as null lose to its older sibling', () => {
+    // Number(null) is a finite 0, so an unusable version must not be read as a
+    // real one: it would lose the version comparison outright and render the
+    // stale document.
+    const fresher = stackBanner({
+      _id: 'fresher',
+      surface: 'modal',
+      cozyMetadata: {
+        createdByApp: 'stack',
+        doctypeVersion: null,
+        updatedAt: '2026-07-20T00:00:00Z'
+      }
+    })
+    const stale = stackBanner({
+      _id: 'stale',
+      cozyMetadata: {
+        createdByApp: 'stack',
+        doctypeVersion: '1',
+        updatedAt: '2026-07-01T00:00:00Z'
+      }
+    })
+
+    expect(getVisibleBanners([fresher, stale], { now })[0]._id).toBe('fresher')
+  })
+
+  it('should fall back on the supported version when the option is unusable', () => {
+    // ?? would let NaN through, and every `version <= NaN` is false, so the
+    // whole feature would go dark with no error.
+    expect(
+      idsOf(
+        getVisibleBanners([stackBanner()], {
+          now,
+          supportedDoctypeVersion: Number('nope')
+        })
+      )
+    ).toEqual(['quota.exceeded'])
+  })
+
+  it('should keep bannerId and _id in separate identities', () => {
+    // A document that lost its bannerId keys on its _id, which must not collide
+    // with another document whose bannerId happens to be that same string.
+    const dismissedNoId = stackBanner({
+      _id: 'quota.exceeded',
+      bannerId: undefined,
+      dismissedAt: '2026-07-20T00:00:00Z'
+    })
+    const live = stackBanner({ _id: 'other' })
+
+    expect(idsOf(getVisibleBanners([dismissedNoId, live], { now }))).toEqual([
+      'quota.exceeded'
+    ])
+  })
+
+  it('should order documents that lost their bannerId deterministically', () => {
+    const first = stackBanner({ _id: 'zzz', bannerId: undefined })
+    const second = stackBanner({ _id: 'aaa', bannerId: undefined })
+
+    const one = getVisibleBanners([first, second], { now }).map(b => b._id)
+    const other = getVisibleBanners([second, first], { now }).map(b => b._id)
+
+    expect(one).toEqual(['aaa', 'zzz'])
+    expect(one).toEqual(other)
+  })
+
+  it('should return the stored document when no fallback applied', () => {
+    // The store relies on referential equality, so an untouched banner must not
+    // be copied on every read.
+    const clean = stackBanner({ cta: null })
+
+    expect(getVisibleBanners([clean], { now })[0]).toBe(clean)
+  })
+
+  it('should fall back on the clock when now is unusable', () => {
+    // The banner is live at the frozen clock, so this separates the guard from
+    // isInWindow's own rejection of a NaN time, which would hide it instead.
+    const live = stackBanner()
+
+    MockDate.set('2026-07-22T12:00:00Z')
+    try {
+      expect(
+        idsOf(getVisibleBanners([live], { now: new Date('nope') }))
+      ).toEqual(['quota.exceeded'])
+      expect(
+        idsOf(getVisibleBanners([live], { now: '2026-07-22T12:00:00Z' }))
+      ).toEqual(['quota.exceeded'])
+    } finally {
+      MockDate.reset()
+    }
+  })
+})
+
+describe('dismiss', () => {
+  const stored = {
+    _id: 'abc',
+    _rev: '1-aaa',
+    bannerId: 'quota.almost-full',
+    severity: 'critical',
+    surface: 'inline',
+    cta: { label: 'Go', url: 'javascript:alert(1)' },
+    dismissedAt: null
+  }
+  const at = '2026-07-22T12:00:00Z'
+
+  // dismiss issues two shapes of query: the collection, to find every version
+  // of the bannerId, then each document by id.
+  const clientReturning = (doc, saveImpl) => ({
+    query: jest
+      .fn()
+      .mockImplementation(definition =>
+        Promise.resolve(
+          definition?.id ? { data: doc } : { data: doc ? [].concat(doc) : [] }
+        )
+      ),
+    save: saveImpl ?? jest.fn().mockResolvedValue({ data: doc })
+  })
+
+  it('should record the timestamp on the stored document', async () => {
+    const client = clientReturning(stored)
+
+    await dismiss(client, stored, { dismissedAt: at })
+
+    expect(client.save).toHaveBeenCalledWith({
+      _type: BANNERS_DOCTYPE,
+      ...stored,
+      dismissedAt: at
+    })
+  })
+
+  it('should write back what the stack stored, not what the caller renders', async () => {
+    // A caller holds a resolved banner, whose severity, surface and cta have
+    // had the client fallbacks applied. Persisting those would overwrite the
+    // values the stack wrote, and nothing server side prevents it.
+    const [resolved] = getVisibleBanners([
+      {
+        ...stored,
+        category: 'quota',
+        text: 'hi',
+        lang: 'en',
+        dismissible: true,
+        priority: 1,
+        startsAt: '2020-01-01T00:00:00Z',
+        endsAt: null,
+        cozyMetadata: { createdByApp: 'stack', doctypeVersion: 1 }
+      }
+    ])
+    const client = clientReturning(stored)
+
+    await dismiss(client, resolved, { dismissedAt: at })
+
+    const persisted = client.save.mock.calls[0][0]
+    expect(persisted.severity).toBe('critical')
+    expect(persisted.surface).toBe('inline')
+    expect(persisted.cta).toEqual(stored.cta)
+  })
+
+  it('should refuse a banner with no identifier', async () => {
+    const client = clientReturning(stored)
+    await expect(dismiss(client, { bannerId: 'x' })).rejects.toThrow('_id')
+    expect(client.save).not.toHaveBeenCalled()
+  })
+
+  it('should stop when the banner was already deleted', async () => {
+    for (const missing of [null, []]) {
+      const client = clientReturning(missing)
+      await expect(
+        dismiss(client, stored, { dismissedAt: at })
+      ).resolves.toEqual({
+        data: null
+      })
+      expect(client.save).not.toHaveBeenCalled()
+    }
+  })
+
+  it('should not rewrite a dismissal another client already recorded', async () => {
+    const already = { ...stored, dismissedAt: '2026-07-20T08:00:00Z' }
+    const client = clientReturning(already)
+
+    await expect(dismiss(client, stored, { dismissedAt: at })).resolves.toEqual(
+      {
+        data: already
+      }
+    )
+    expect(client.save).not.toHaveBeenCalled()
+  })
+
+  it('should read the document back and write again on a conflict', async () => {
+    const conflict = Object.assign(new Error('Document update conflict'), {
+      status: 409
+    })
+    const fresh = { ...stored, _rev: '2-bbb' }
+    // The first read returns the revision that loses the race and the second
+    // the one that wins, so the assertion fails unless the document really was
+    // read again rather than the losing revision retried.
+    const client = {
+      query: jest
+        .fn()
+        // the collection lookup for every version of the bannerId
+        .mockResolvedValueOnce({ data: [stored] })
+        // the read by id, then the re-read after the conflict
+        .mockResolvedValueOnce({ data: stored })
+        .mockResolvedValue({ data: fresh }),
+      save: jest
+        .fn()
+        .mockRejectedValueOnce(conflict)
+        .mockResolvedValue({})
+    }
+
+    await dismiss(client, stored, { dismissedAt: at })
+
+    expect(client.query).toHaveBeenCalledTimes(3)
+    expect(client.save).toHaveBeenLastCalledWith({
+      ...fresh,
+      _type: BANNERS_DOCTYPE,
+      dismissedAt: at
+    })
+  })
+
+  it('should give up rather than loop when the retry conflicts too', async () => {
+    const conflict = Object.assign(new Error('Document update conflict'), {
+      status: 409
+    })
+    const client = clientReturning(
+      stored,
+      jest.fn().mockRejectedValue(conflict)
+    )
+
+    await expect(dismiss(client, stored, { dismissedAt: at })).rejects.toThrow(
+      'Document update conflict'
+    )
+    expect(client.save).toHaveBeenCalledTimes(2)
+  })
+
+  it('should classify a conflict the pouch link rewrapped without a status', async () => {
+    // CozyPouchLink rebuilds the error and keeps only the message, so the
+    // status branch cannot be the one that recognises it.
+    const rewrapped = new Error(
+      'Coud not apply mutation: Document update conflict'
+    )
+    const client = clientReturning(
+      stored,
+      jest
+        .fn()
+        .mockRejectedValueOnce(rewrapped)
+        .mockResolvedValue({ data: stored })
+    )
+
+    await dismiss(client, stored, { dismissedAt: at })
+
+    expect(client.save).toHaveBeenCalledTimes(2)
+  })
+
+  it('should read the document the pouch link resolves as an array', async () => {
+    const client = clientReturning([stored])
+
+    await dismiss(client, stored, { dismissedAt: at })
+
+    expect(client.save).toHaveBeenCalledWith({
+      ...stored,
+      _type: BANNERS_DOCTYPE,
+      dismissedAt: at
+    })
+  })
+
+  it('should write to the banners doctype whatever _type the document carries', async () => {
+    // Nothing server side stops an application from persisting a _type of its
+    // own on a stack authored banner, and the spread order decides where the
+    // write lands.
+    const poisoned = { ...stored, _type: 'io.cozy.settings' }
+    const client = clientReturning(poisoned)
+
+    await dismiss(client, poisoned, { dismissedAt: at })
+
+    expect(client.save.mock.calls[0][0]._type).toBe(BANNERS_DOCTYPE)
+  })
+
+  it('should not report a failed read as a deleted banner', async () => {
+    // client.query resolves undefined when the client swallows the rejection
+    // through its onError option. Reporting that as {data: null} would tell the
+    // caller the banner is gone while nothing was written.
+    const client = {
+      query: jest.fn().mockResolvedValue(undefined),
+      save: jest.fn()
+    }
+
+    await expect(dismiss(client, stored, { dismissedAt: at })).rejects.toThrow(
+      'resolved nothing'
+    )
+    expect(client.save).not.toHaveBeenCalled()
+  })
+
+  it('should not swallow any other error', async () => {
+    const boom = Object.assign(new Error('Server error'), { status: 500 })
+    const client = clientReturning(stored, jest.fn().mockRejectedValue(boom))
+
+    await expect(dismiss(client, stored)).rejects.toThrow('Server error')
+  })
+})
+
+describe('getCta url validation', () => {
+  const withUrl = url => ({ cta: { label: 'Go', url } })
+
+  it('should keep an absolute https URL', () => {
+    expect(getCta(withUrl('https://example.org/plans'))).not.toBeNull()
+  })
+
+  it.each([
+    ['https://', 'a scheme with no host'],
+    ['http://example.org', 'plain http'],
+    ['javascript:alert(1)', 'a script scheme'],
+    ['//example.org', 'a protocol relative URL'],
+    ['/plans', 'a relative path']
+  ])('should drop %s (%s)', url => {
+    expect(getCta(withUrl(url))).toBeNull()
+  })
+})
+
+describe('getActiveBanners', () => {
+  const stored = {
+    _id: 'abc',
+    bannerId: 'quota.almost-full',
+    category: 'quota',
+    severity: 'critical',
+    surface: 'inline',
+    text: 'hi',
+    lang: 'en',
+    dismissible: true,
+    dismissedAt: null,
+    priority: 10,
+    startsAt: '2020-01-01T00:00:00Z',
+    endsAt: null,
+    cozyMetadata: { createdByApp: 'stack', doctypeVersion: '1' }
+  }
+
+  it('should query and return banners ready to render', async () => {
+    const client = { query: jest.fn().mockResolvedValue({ data: [stored] }) }
+
+    const banners = await getActiveBanners(client)
+
+    // asserted precisely: passing the { definition, options } wrapper instead
+    // of the definition itself throws "Cannot init query with no doctype" at
+    // runtime, which a permissive mock hides.
+    const [definition, queryOptions] = client.query.mock.calls[0]
+    expect(definition.doctype).toBe(BANNERS_DOCTYPE)
+    // Named under its own key rather than the bare doctype: client.query keys
+    // the store entry on the name but the in flight promise on the definition,
+    // so sharing the name with another query makes this one resolve nothing.
+    expect(queryOptions.as).toBe(BANNERS_QUERY_NAME)
+    expect(BANNERS_QUERY_NAME).not.toBe(BANNERS_DOCTYPE)
+    expect(banners).toHaveLength(1)
+    // fallbacks already applied, so the caller renders what it is given
+    expect(banners[0].severity).toBe('warning')
+    expect(banners[0].surface).toBe('banner')
+  })
+
+  it('should cope with an empty or missing collection', async () => {
+    for (const data of [[], null, undefined]) {
+      const client = { query: jest.fn().mockResolvedValue({ data }) }
+      await expect(getActiveBanners(client)).resolves.toEqual([])
+    }
+  })
+
+  it('should read a collection the pouch link resolves as a bare object', async () => {
+    const client = { query: jest.fn().mockResolvedValue({ data: stored }) }
+    await expect(getActiveBanners(client)).resolves.toEqual([])
+  })
+
+  it('should not report a query that resolved nothing as an empty instance', async () => {
+    const client = { query: jest.fn().mockResolvedValue(undefined) }
+    await expect(getActiveBanners(client)).rejects.toThrow('resolved nothing')
+  })
+})
+
+describe('getActiveBanner', () => {
+  it('should return the highest priority banner', async () => {
+    const low = {
+      _id: 'a',
+      bannerId: 'low',
+      severity: 'info',
+      surface: 'banner',
+      priority: 1,
+      dismissedAt: null,
+      startsAt: '2020-01-01T00:00:00Z',
+      endsAt: null,
+      cozyMetadata: { createdByApp: 'stack', doctypeVersion: '1' }
+    }
+    const high = { ...low, _id: 'b', bannerId: 'high', priority: 99 }
+    const client = { query: jest.fn().mockResolvedValue({ data: [low, high] }) }
+
+    const banner = await getActiveBanner(client)
+
+    expect(banner.bannerId).toBe('high')
+  })
+
+  it('should return null when nothing applies', async () => {
+    const client = { query: jest.fn().mockResolvedValue({ data: [] }) }
+    await expect(getActiveBanner(client)).resolves.toBeNull()
+  })
+})
+
+describe('dismiss across versions', () => {
+  const at = '2026-08-28T10:00:00Z'
+  const v1 = {
+    _id: 'v1doc',
+    bannerId: 'quota.exceeded',
+    dismissedAt: null,
+    cozyMetadata: { createdByApp: 'stack', doctypeVersion: '1' }
+  }
+  const v2 = {
+    ...v1,
+    _id: 'v2doc',
+    cozyMetadata: { ...v1.cozyMetadata, doctypeVersion: '2' }
+  }
+  const other = { ...v1, _id: 'otherdoc', bannerId: 'billing.failed' }
+
+  it('should write the dismissal to every version of the bannerId', async () => {
+    const byId = { v1doc: v1, v2doc: v2, otherdoc: other }
+    const client = {
+      query: jest
+        .fn()
+        .mockImplementation(definition =>
+          Promise.resolve(
+            definition?.id
+              ? { data: byId[definition.id] }
+              : { data: [v1, v2, other] }
+          )
+        ),
+      save: jest.fn().mockImplementation(doc => Promise.resolve({ data: doc }))
+    }
+
+    await dismiss(client, v1, { dismissedAt: at })
+
+    const written = client.save.mock.calls.map(([doc]) => doc._id).sort()
+    expect(written).toEqual(['v1doc', 'v2doc'])
+    // the sibling under a different bannerId is left alone
+    expect(written).not.toContain('otherdoc')
+  })
+
+  it('should answer with the document the caller asked about', async () => {
+    const client = {
+      query: jest
+        .fn()
+        .mockImplementation(definition =>
+          Promise.resolve(
+            definition?.id
+              ? { data: definition.id === 'v1doc' ? v1 : v2 }
+              : { data: [v1, v2] }
+          )
+        ),
+      save: jest.fn().mockImplementation(doc => Promise.resolve({ data: doc }))
+    }
+
+    const result = await dismiss(client, v2, { dismissedAt: at })
+
+    expect(result.data._id).toBe('v2doc')
+  })
+})

--- a/packages/cozy-client/src/models/index.js
+++ b/packages/cozy-client/src/models/index.js
@@ -19,6 +19,7 @@ import * as geo from './geo'
 import * as doctypes from './doctypes'
 import * as ai from './ai'
 import * as assistant from './assistant'
+import * as banner from './banner'
 
 // For backward compatibility before 9.0.0
 const triggers = trigger
@@ -26,6 +27,7 @@ const accounts = account
 
 export {
   triggers,
+  banner,
   trigger,
   instance,
   applications,

--- a/packages/cozy-client/types/models/banner.d.ts
+++ b/packages/cozy-client/types/models/banner.d.ts
@@ -1,0 +1,193 @@
+export const BANNERS_DOCTYPE: "io.cozy.banners";
+/**
+ * The version of the io.cozy.banners shape this code was written against.
+ * A document declaring a higher cozyMetadata.doctypeVersion is skipped.
+ */
+export const SUPPORTED_DOCTYPE_VERSION: 1;
+/**
+ * The severities the doctype defines. A value outside this list is rendered
+ * with DEFAULT_SEVERITY. Frozen because the fallbacks read it at call time, so
+ * a consumer mutating it would change what every other consumer renders.
+ *
+ * @type {readonly BannerSeverity[]}
+ */
+export const KNOWN_SEVERITIES: readonly BannerSeverity[];
+/**
+ * The surfaces the doctype defines. A value outside this list is rendered on
+ * DEFAULT_SURFACE. Frozen for the same reason as KNOWN_SEVERITIES.
+ *
+ * @type {readonly BannerSurface[]}
+ */
+export const KNOWN_SURFACES: readonly BannerSurface[];
+/**
+ * @typedef {object} BannerCta
+ * @property {string} label - The label, plain text, in the same language as the banner text
+ * @property {string} url - Absolute https URL the label points to
+ */
+/**
+ * @typedef {'quota'|'billing'|'trial'|'account'|'system'} BannerCategory
+ */
+/**
+ * @typedef {'info'|'warning'|'error'} BannerSeverity
+ */
+/**
+ * @typedef {'banner'|'modal'} BannerSurface
+ */
+/**
+ * @typedef {object} VisibleBannersOptions
+ * @property {Date} [now] - The current time, defaults to now
+ * @property {number} [supportedDoctypeVersion] - The highest version this client handles
+ */
+/**
+ * @typedef {import("../CozyClient").default} BannerClient A CozyClient instance
+ */
+/**
+ * @typedef {object} DismissOptions
+ * @property {string} [dismissedAt] - The timestamp to record, defaults to now
+ */
+/**
+ * @typedef {object} Banner An io.cozy.banners document
+ * @property {string} [_id] - Identifier of the document, minted by CouchDB
+ * @property {string} [_rev] - Revision identifier of the document
+ * @property {string} bannerId - Identifier of the banner itself
+ * @property {BannerCategory} category - What the banner is about
+ * @property {BannerSeverity} severity - info, warning or error
+ * @property {BannerSurface} surface - banner or modal
+ * @property {string} text - The message, in the language given by lang
+ * @property {string} lang - BCP 47 tag of the language text is written in
+ * @property {BannerCta|null} [cta] - Optional call to action
+ * @property {boolean} dismissible - Whether the client offers a dismiss control
+ * @property {string|null} [dismissedAt] - When the user dismissed this banner
+ * @property {number} priority - Sort order, highest first
+ * @property {string} startsAt - Start of the validity window, inclusive
+ * @property {string|null} [endsAt] - End of the validity window, exclusive
+ * @property {object} [source] - What produced the document
+ * @property {object} [cozyMetadata] - Document lifecycle metadata
+ */
+/**
+ * The name the banners query is stored under. It is namespaced rather than the
+ * bare doctype: `client.query` keys the store entry on this name but keys the
+ * in-flight promise on the definition, so an unrelated consumer naming its own
+ * `io.cozy.banners` query would make this one resolve nothing while that query
+ * is loading.
+ */
+export const BANNERS_QUERY_NAME: string;
+export function buildBannersQuery(): import('../types').Query;
+export function isTrusted(banner: Banner): boolean;
+export function isSupported(banner: Banner, supportedVersion?: number): boolean;
+export function isDismissed(banner: Banner): boolean;
+export function isInWindow(banner: Banner, now?: Date): boolean;
+export function byPriority(a: Banner, b: Banner): number;
+export function getSeverity(banner: Banner): BannerSeverity;
+export function getSurface(banner: Banner): BannerSurface;
+export function getCta(banner: Banner): BannerCta | null;
+export function getVisibleBanners(banners: Banner[], options?: VisibleBannersOptions): Banner[];
+export function getActiveBanners(client: BannerClient, options?: VisibleBannersOptions): Promise<Banner[]>;
+export function getActiveBanner(client: BannerClient, options?: VisibleBannersOptions): Promise<Banner | null>;
+export function dismiss(client: BannerClient, banner: Banner & {
+    _id: string;
+}, options?: DismissOptions): Promise<{
+    data: Banner | null;
+}>;
+export type BannerCta = {
+    /**
+     * - The label, plain text, in the same language as the banner text
+     */
+    label: string;
+    /**
+     * - Absolute https URL the label points to
+     */
+    url: string;
+};
+export type BannerCategory = "account" | "quota" | "billing" | "trial" | "system";
+export type BannerSeverity = "info" | "error" | "warning";
+export type BannerSurface = "banner" | "modal";
+export type VisibleBannersOptions = {
+    /**
+     * - The current time, defaults to now
+     */
+    now?: Date;
+    /**
+     * - The highest version this client handles
+     */
+    supportedDoctypeVersion?: number;
+};
+/**
+ * A CozyClient instance
+ */
+export type BannerClient = import("../CozyClient").default;
+export type DismissOptions = {
+    /**
+     * - The timestamp to record, defaults to now
+     */
+    dismissedAt?: string;
+};
+/**
+ * An io.cozy.banners document
+ */
+export type Banner = {
+    /**
+     * - Identifier of the document, minted by CouchDB
+     */
+    _id?: string;
+    /**
+     * - Revision identifier of the document
+     */
+    _rev?: string;
+    /**
+     * - Identifier of the banner itself
+     */
+    bannerId: string;
+    /**
+     * - What the banner is about
+     */
+    category: BannerCategory;
+    /**
+     * - info, warning or error
+     */
+    severity: BannerSeverity;
+    /**
+     * - banner or modal
+     */
+    surface: BannerSurface;
+    /**
+     * - The message, in the language given by lang
+     */
+    text: string;
+    /**
+     * - BCP 47 tag of the language text is written in
+     */
+    lang: string;
+    /**
+     * - Optional call to action
+     */
+    cta?: BannerCta | null;
+    /**
+     * - Whether the client offers a dismiss control
+     */
+    dismissible: boolean;
+    /**
+     * - When the user dismissed this banner
+     */
+    dismissedAt?: string | null;
+    /**
+     * - Sort order, highest first
+     */
+    priority: number;
+    /**
+     * - Start of the validity window, inclusive
+     */
+    startsAt: string;
+    /**
+     * - End of the validity window, exclusive
+     */
+    endsAt?: string | null;
+    /**
+     * - What produced the document
+     */
+    source?: object;
+    /**
+     * - Document lifecycle metadata
+     */
+    cozyMetadata?: object;
+};

--- a/packages/cozy-client/types/models/index.d.ts
+++ b/packages/cozy-client/types/models/index.d.ts
@@ -1,4 +1,5 @@
 export const triggers: typeof trigger;
+import * as banner from "./banner";
 import * as trigger from "./trigger";
 import * as instance from "./instance";
 import * as applications from "./applications";
@@ -21,4 +22,4 @@ import * as geo from "./geo";
 import * as doctypes from "./doctypes";
 import * as ai from "./ai";
 import * as assistant from "./assistant";
-export { trigger, instance, applications, file, folder, konnectorFolder, note, account, permission, utils, contact, document, timeseries, sharing, dacc, paper, user, geo, doctypes, ai, assistant };
+export { banner, trigger, instance, applications, file, folder, konnectorFolder, note, account, permission, utils, contact, document, timeseries, sharing, dacc, paper, user, geo, doctypes, ai, assistant };


### PR DESCRIPTION
## Context

`io.cozy.banners` holds the platform messages shown to a user across applications. Every client that reads the doctype has to order the documents, evaluate a validity window, honour a dismissal, fall back on values it does not know and skip a shape it cannot read. Left to each application, those rules get written several times and drift.

## Solution

A model of pure functions for the read side, plus `dismiss` which retries once on a conflict since the field is idempotent.

The spec runs the contract vectors published with the doctype, so this implementation and the ones on other platforms are checked against the same cases rather than against each other. Polling is left to the caller: the model only decides what is visible at a given time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving trusted banners.
  - Banners now respect scheduling, priority, dismissal status, supported versions, and display surfaces.
  - Added fallbacks for unknown categories, severities, and surfaces.
  - Validated secure call-to-action links.
  - Added reliable banner dismissal with conflict recovery.

- **Documentation**
  - Added API documentation and TypeScript types for banners.

- **Tests**
  - Added coverage for banner visibility, ordering, filtering, fallbacks, trust, version handling, and dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->