### PR TITLE
fix(ci): catch generated files that are missing entirely

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,11 +34,14 @@ jobs:
         run: yarn docs
       - name: Check documentation
         run: |
-          git diff --exit-code -- docs || (echo "Docs are not up-to-date, please run yarn docs and repush" && exit 1)
+          git add -A -- docs
+          git diff --cached --exit-code -- docs || (echo "Docs are not up-to-date, please run yarn docs and repush" && exit 1)
       - name: Make types
         run: yarn types
       - name: Check types
-        run: git diff --exit-code || (echo "Types are not up-to-date, please run cd packages/cozy-client && yarn typecheck and repush" && exit 1)
+        run: |
+          git add -A
+          git diff --cached --exit-code || (echo "Types are not up-to-date, please run cd packages/cozy-client && yarn typecheck and repush" && exit 1)
       - name: Publish to NPM
         if: github.ref == 'refs/heads/master'
         env:


### PR DESCRIPTION
## Context

The documentation and types checks compare the working tree with `git diff --exit-code`, which reads tracked files only. A generated file for a module that did not exist before comes back untracked, so the gate passes on a branch that never committed it. The check therefore catches a declaration that drifted, but not one that is missing altogether.

## Solution

Stage before comparing. `git add -A` honours `.gitignore`, so build output is left alone and a branch with nothing to regenerate still passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated documentation and type checks to detect newly created files, in addition to changes to existing files.
  - This provides more comprehensive validation during builds and helps prevent incomplete or inconsistent changes from passing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->