### PR TITLE
fix: Dummy commit for release

### DIFF
--- a/docs/api/cozy-client/classes/CozyClient.md
+++ b/docs/api/cozy-client/classes/CozyClient.md
@@ -1116,7 +1116,7 @@ Emits event when token is refreshed
 Resolves relationships on a document.
 
 The original document is kept in the target attribute of
-the relationship
+the relationship.
 
 *Parameters*
 

--- a/packages/cozy-client/src/CozyClient.js
+++ b/packages/cozy-client/src/CozyClient.js
@@ -1329,7 +1329,7 @@ client.query(Q('io.cozy.bills'))`)
    * Resolves relationships on a document.
    *
    * The original document is kept in the target attribute of
-   * the relationship
+   * the relationship.
    *
    * @param  {import("./types").CozyClientDocument} document - for which relationships must be resolved
    * @param  {Schema} [schemaArg] - The schema describing the relationships

--- a/packages/cozy-client/types/CozyClient.d.ts
+++ b/packages/cozy-client/types/CozyClient.d.ts
@@ -595,7 +595,7 @@ declare class CozyClient {
      * Resolves relationships on a document.
      *
      * The original document is kept in the target attribute of
-     * the relationship
+     * the relationship.
      *
      * @param  {import("./types").CozyClientDocument} document - for which relationships must be resolved
      * @param  {Schema} [schemaArg] - The schema describing the relationships


### PR DESCRIPTION
npm releases were stuck because of bad auth.
This dummy commit is to release the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the original document remains available in a relationship’s `target` attribute after hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->